### PR TITLE
修复：app 在后台时打开链接无法跳转到新页面

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,6 +45,9 @@
                 <data android:scheme="https"/>
                 <data android:host="hitomi.la"/>
             </intent-filter>
+            <meta-data 
+                android:name="flutter_deeplinking_enabled"
+                android:value="false" />
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->


### PR DESCRIPTION
修复 https://github.com/Pacalini/PicaComic/issues/117

禁用 flutter 自身的 deeplink 逻辑，因为这似乎会重新路由到首页，参见：

https://github.com/flutter/flutter/blob/1bbbf060f14f23485ce5a83b2f13725a3a6ed6ac/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java#L949