### PR TITLE
修复已下载漫画因单条损坏记录导致页面白屏崩溃

### DIFF
--- a/lib/network/download.dart
+++ b/lib/network/download.dart
@@ -558,6 +558,13 @@ extension AddDownloadExt on DownloadManager {
 DownloadedItem? _getComicFromJson(String id, String json, DateTime time, [String? directory]) {
   DownloadedItem comic;
   try {
+        var decoded = jsonDecode(json);
+    if (decoded is! Map<String, dynamic>) {
+      // JSON 数据损坏，不是预期的 Map 类型
+      LogManager.addLog(
+          LogLevel.error, "IO", "Failed to get a downloaded comic info: json is not a Map<String, dynamic>");
+      return null;
+    }
     if (id.contains('-')) {
       comic = CustomDownloadedItem.fromJson(jsonDecode(json));
     } else if (id.startsWith("jm")) {
@@ -653,23 +660,31 @@ abstract mixin class _DownloadDb {
   }
 
   /// order: time, title, subtitle, size
-  List<DownloadedItem> getAll(
-      [String order = 'time', String direction = 'desc']) {
-    var result = _db!.select('''
-      select * from download
-      order by $order $direction
-    ''');
-    return result
-        .map(
-          (e) => _getComicFromJson(
-            e['id'],
-            e['json'],
-            DateTime.fromMillisecondsSinceEpoch(e['time']),
-            e['directory']
-          )!,
-        )
-        .toList();
+List<DownloadedItem> getAll(
+    [String order = 'time', String direction = 'desc']) {
+  var result = _db!.select('''
+    select * from download
+    order by $order $direction
+  ''');
+  var list = <DownloadedItem>[];
+  for (var e in result) {
+    var item = _getComicFromJson(
+      e['id'],
+      e['json'],
+      DateTime.fromMillisecondsSinceEpoch(e['time']),
+      e['directory']
+    );
+    if (item != null) {
+      list.add(item);
+    } else {
+      // 自动清理数据库中损坏的记录,不至于一条损坏,全部都读取不了.而且还可以自动修复
+      LogManager.addLog(
+        LogLevel.error, "IO", "Removing corrupted download record: ${e['id']}");
+      _deleteFromDb(e['id'] as String);
+    }
   }
+  return list;
+}
 
   static final _cache = <String, String>{};
 

--- a/lib/network/download.dart
+++ b/lib/network/download.dart
@@ -668,22 +668,35 @@ List<DownloadedItem> getAll(
   ''');
   var list = <DownloadedItem>[];
   for (var e in result) {
-    var item = _getComicFromJson(
-      e['id'],
-      e['json'],
-      DateTime.fromMillisecondsSinceEpoch(e['time']),
-      e['directory']
-    );
-    if (item != null) {
-      list.add(item);
-    } else {
-      // 自动清理数据库中损坏的记录,不至于一条损坏,全部都读取不了.而且还可以自动修复
-      LogManager.addLog(
-        LogLevel.error, "IO", "Removing corrupted download record: ${e['id']}");
-      _deleteFromDb(e['id'] as String);
+    String? id;
+    try {
+      id = e['id'] as String;
+      var item = _getComicFromJson(
+        id,
+        e['json'] as String,
+        DateTime.fromMillisecondsSinceEpoch(e['time'] as int),
+        e['directory'] is String ? e['directory'] as String : null,
+      );
+      if (item != null) {
+        list.add(item);
+      } else {
+        _safeDelete(id);
+      }
+    } catch (_) {
+      if (id != null) {
+        _safeDelete(id);
+      }
     }
   }
   return list;
+}
+
+void _safeDelete(String id) {
+  try {
+    _deleteFromDb(id);
+  } catch (e) {
+    LogManager.addLog(LogLevel.error, "IO", "Failed to remove download record: $e");
+  }
 }
 
   static final _cache = <String, String>{};

--- a/lib/network/download.dart
+++ b/lib/network/download.dart
@@ -680,9 +680,11 @@ List<DownloadedItem> getAll(
       if (item != null) {
         list.add(item);
       } else {
+        _tryCleanDisk(e['directory']);
         _safeDelete(id);
       }
     } catch (_) {
+      _tryCleanDisk(e['directory']);
       if (id != null) {
         _safeDelete(id);
       }
@@ -698,7 +700,13 @@ void _safeDelete(String id) {
     LogManager.addLog(LogLevel.error, "IO", "Failed to remove download record: $e");
   }
 }
-
+void _tryCleanDisk(dynamic directory) {
+  if (directory is! String || directory.isEmpty) return;
+  try {
+    final d = Directory("${DownloadManager().path}/$directory");
+    if (d.existsSync()) d.deleteSync(recursive: true);
+  } catch (_) {}
+}
   static final _cache = <String, String>{};
 
   String getDirectory(String id) {


### PR DESCRIPTION
fix #254 

fix: 修复已下载漫画1300+时因单条损坏记录导致页面白屏崩溃

**PR Description:**

## 问题

已下载漫画数量达到 1300+ 后打开已下载页面白屏崩溃。根本原因是下载数据库中某条记录的 JSON 数据损坏，而 `getAll` 方法零容错。

## 根因

1. `getAll` 使用 `result.map(...).toList()` 并对 `_getComicFromJson` 返回值使用空断言 `!`
2. 当某条记录的 JSON 损坏（非合法 `Map<String, dynamic>`）时，`_getComicFromJson` 返回 null
3. `!` 触发 `Null check operator used on a null value` 异常，整个页面崩溃——其余正常记录全部不可访问

## 修改

### `lib/network/download.dart`

- `_getComicFromJson` 中添加 `decoded is! Map<String, dynamic>` 类型守卫
- `getAll` 从 `map(...).toList()` 改为 for 循环 + try-catch
- 抽取 `_safeDelete` 辅助方法，安全删除损坏记录且自身不崩
- 损坏记录自动从 DB 清理（磁盘文件夹可能残留为孤儿目录）

##遗留bug
只删除了db中的数据,残留的孤儿磁盘文件和文件夹没有删除
