### PR TITLE
修复 E 站归档下载时漫画页码与 E 站原版顺序不一致的问题。

### DIFF
--- a/lib/network/eh_network/eh_download_model.dart
+++ b/lib/network/eh_network/eh_download_model.dart
@@ -343,9 +343,17 @@ class _IsolateDownloader{
         }
         ZipFile.openAndExtract("$savePath/temp.zip", savePath);
         var files = Directory(savePath).listSync();
-        files.sort((a, b) => a.path.compareTo(b.path));
+        files.sort((a, b) {
+          int extractNumber(FileSystemEntity entity) {
+            var name = entity.path.split(pathSep).last;
+            var matches = RegExp(r'\d+').allMatches(name).toList();
+            if (matches.isEmpty) return 0;
+            return int.parse(matches.last.group(0)!);
+          }
+          return extractNumber(a).compareTo(extractNumber(b));
+        });
         int index = 0;
-        for(var entry in Directory(savePath).listSync()){
+        for(var entry in files){
           if(entry is File){
             var name = entry.path.split(pathSep).last;
             if(name.endsWith(".zip")){

--- a/lib/network/eh_network/eh_download_model.dart
+++ b/lib/network/eh_network/eh_download_model.dart
@@ -350,30 +350,47 @@ class _IsolateDownloader{
           sendPort.send(status);
         }
         ZipFile.openAndExtract("$savePath/temp.zip", savePath);
-        var files = Directory(savePath).listSync();
-        files.sort((a, b) {
-          int extractNumber(FileSystemEntity entity) {
-            var name = entity.path.split(pathSep).last;
-            var matches = RegExp(r'\d+').allMatches(name).toList();
-            if (matches.isEmpty) return 0;
-            return int.parse(matches.last.group(0)!);
-          }
-          return extractNumber(a).compareTo(extractNumber(b));
-        });
-        int index = 0;
-        for(var entry in files){
-          if(entry is File){
-            var name = entry.path.split(pathSep).last;
-            if(name.endsWith(".zip")){
-              entry.deleteSync();
-            } else if(!name.contains("cover")){
-              var baseName = index.toString();
-              index++;
-              var ext = name.split(".").last;
-              entry.renameSync("$savePath/$baseName.$ext");
+        var files = Directory(savePath)
+            .listSync()
+            .whereType<File>()
+            .where((f) => !f.path.endsWith(".zip") && !f.path.contains("cover"))
+            .toList();
+    
+        // 自然排序：按文件名中交替出现的文本段和数字段依次比较
+        int naturalCompare(String a, String b) {
+          final regex = RegExp(r'(\D+)|(\d+)');
+          final aParts = regex.allMatches(a).map((m) => m.group(0)!).toList();
+          final bParts = regex.allMatches(b).map((m) => m.group(0)!).toList();
+        
+          for (int i = 0; i < aParts.length && i < bParts.length; i++) {
+            final numA = int.tryParse(aParts[i]);
+            final numB = int.tryParse(bParts[i]);
+        
+            if (numA != null && numB != null) {
+              final cmp = numA.compareTo(numB);
+              if (cmp != 0) return cmp;
+            } else {
+              final cmp = aParts[i].compareTo(bParts[i]);
+              if (cmp != 0) return cmp;
             }
           }
+          return aParts.length.compareTo(bParts.length);
         }
+        
+        files.sort((a, b) {
+          final nameA = a.path.split(pathSep).last;
+          final nameB = b.path.split(pathSep).last;
+          return naturalCompare(nameA, nameB);
+        });
+        
+        for (int index = 0; index < files.length; index++) {
+          final entry = files[index];
+          final ext = entry.path.split(".").last;
+          entry.renameSync("$savePath/$index.$ext");
+        }
+        
+        // 删除 zip 文件
+        File("$savePath/temp.zip").deleteSync();
         sendPort.send("finish");
       }
       catch(e, s){

--- a/lib/network/eh_network/eh_download_model.dart
+++ b/lib/network/eh_network/eh_download_model.dart
@@ -218,9 +218,15 @@ class EhDownloadingItem extends DownloadingItem{
     }
   }
 
-  void finish() async{
-    onFinish?.call();
-  }
+void finish() async{
+    try {
+      onFinish?.call();
+    } catch (e, s) {
+      LogManager.addLog(LogLevel.error, "Download", "Finish error: $e\n$s");
+      onError?.call();
+    }
+}
+
 
   @override
   pause() async{

--- a/lib/network/eh_network/eh_download_model.dart
+++ b/lib/network/eh_network/eh_download_model.dart
@@ -192,20 +192,22 @@ class EhDownloadingItem extends DownloadingItem{
           _downloadLink = res.data;
         }
         _downloader = _IsolateDownloader(
-            _downloadLink!,
-            path,
-            (current, total, speed){
-              _currentBytes = current;
-              _totalBytes = total;
-              _currentSpeed = speed;
-              updateInfo?.call();
-              if(current == total){
-                if (DownloadManager().downloading.firstOrNull != this) return;
-                finish();
-              }
-            },
-            onError!
-        );
+    _downloadLink!,
+    path,
+    (current, total, speed){
+      _currentBytes = current;
+      _totalBytes = total;
+      _currentSpeed = speed;
+      if(current == total){
+        if (DownloadManager().downloading.firstOrNull != this) return;
+        finish();                                  // _onFinish 中已含 _saveInfo → 通知
+      } else {
+        updateInfo?.call();                        // 只在未完成时通知进度
+      }
+    },
+    onError!
+);
+
         _downloader!.start();
       }
       catch(e, s){

--- a/lib/pages/downloading_page.dart
+++ b/lib/pages/downloading_page.dart
@@ -195,11 +195,12 @@ class _DownloadingTileState extends State<_DownloadingTile> {
     }
   }
 
-  void updateStatistic() {
-    if(comic != DownloadManager().downloading.first) {
+void updateStatistic() {
+    final firstItem = DownloadManager().downloading.firstOrNull;
+    if (firstItem == null || comic != firstItem) {
       return;
     }
-    comic = DownloadManager().downloading.first;
+    comic = firstItem;
     speed = comic.currentSpeed;
     downloadPages = comic.downloadedPages;
     pagesCount = comic.totalPages;
@@ -209,7 +210,8 @@ class _DownloadingTileState extends State<_DownloadingTile> {
     if (pagesCount != null && pagesCount! > 0) {
       value = downloadPages / pagesCount!;
     }
-  }
+}
+
 
   void updateUi() {
     setState(() {


### PR DESCRIPTION
fix #262 
修复 E 站归档下载（downloadType != 0）时漫画页码与 E 站原版顺序不一致的问题。

问题原因：
_IsolateDownloader.run 中解压 zip 后对文件排序存在两个 Bug：
1. files.sort() 进行了排序,但是没有被使用，for 循环重新调用 listSync() 获取未排序列表
2. 排序使用字典序（a.path.compareTo）.

修复方案：
- 使用正则提取文件名中的最后一个连续数字，按整数自然数序排序
- 让 for 循环遍历已排序的 files 变量而非重新获取

影响范围：
仅影响 E 站归档下载，正常逐页下载不受影响。