### PR TITLE
下载页删除后保持滚动位置

### DIFF
--- a/lib/pages/download_page.dart
+++ b/lib/pages/download_page.dart
@@ -566,7 +566,13 @@ class DownloadPage extends StatelessWidget {
                               }
                             }
                             await downloadManager.delete(comics);
-                            logic.refresh();
+                            //logic.refresh();
+                              logic.comics.removeWhere((c) => comics.contains(c.id));
+                              logic.baseComics.removeWhere((c) => comics.contains(c.id));
+                              logic.searchMode = false;
+                              logic.selecting = false;
+                              logic.resetSelected(logic.comics.length);
+                              logic.update();
                           },
                           child: Text("确认".tl)),
                     ],


### PR DESCRIPTION
下载页删除后保持滚动位置
原版:logic.refresh()通过切换 loading 标志让整个 SmoothCustomScrollView 被销毁重建，ScrollController 丢失 → 回到顶部。 修改方案:直接从列表中移除已删项，控件树不变 ,滚动位置保留