### PR TITLE
从下载记录,收藏夹和已下载页面进入漫画详情页支持离线先本地后网络的分阶段加载

### DIFF
--- a/lib/pages/comic_page.dart
+++ b/lib/pages/comic_page.dart
@@ -18,6 +18,7 @@ import 'package:pica_comic/foundation/log.dart';
 import 'package:pica_comic/foundation/stack.dart' as stack;
 import 'package:pica_comic/foundation/ui_mode.dart';
 import 'package:pica_comic/network/base_comic.dart';
+import 'package:pica_comic/network/custom_download_model.dart';
 import 'package:pica_comic/network/download.dart';
 import 'package:pica_comic/network/res.dart';
 import 'package:pica_comic/pages/favorites/local_favorites.dart';
@@ -160,7 +161,68 @@ class _ComicPageImpl extends BaseComicPage<ComicInfoData> {
 
   @override
   Future<bool> loadFavorite(ComicInfoData data) async {
-    return data.isFavorite ?? false;
+    bool platformFavorite = data.isFavorite ?? false;
+    bool localFavorite = LocalFavoritesManager().isExist(id);
+    return platformFavorite || localFavorite;
+  }
+
+  @override
+  Future<ComicInfoData?> loadLocalData() async {
+    final downloadId = DownloadManager().generateId(sourceKey, id);
+
+    // 优先级1：已下载的记录（数据最完整：title、cover、tags、可能包含 chapters）
+    DownloadedItem? downloaded;
+    try {
+      if (DownloadManager().isExists(downloadId)) {
+        downloaded = await DownloadManager().getComicOrNull(downloadId);
+      }
+    } catch (_) {}
+
+    if (downloaded != null) {
+      return ComicInfoData(
+        downloaded.name,
+        downloaded.subTitle,
+        downloaded.cover,
+        null,
+        _tagsListToMap(downloaded.tags),
+        downloaded is CustomDownloadedItem
+            ? (downloaded as CustomDownloadedItem).chapters
+            : null,
+        null,
+        null,
+        0,
+        null,
+        sourceKey,
+        id,
+      );
+    }
+
+    // 优先级2：阅读历史（已在 get() 阶段1中查询，存在 _logic.history 中）
+    final h = _logic.history;
+    if (h != null && h.title.isNotEmpty) {
+      return ComicInfoData(
+        h.title,
+        h.subtitle,
+        h.cover,
+        null,
+        {},
+        null,
+        null,
+        null,
+        0,
+        null,
+        sourceKey,
+        id,
+      );
+    }
+
+    return null;
+  }
+
+  /// 辅助方法：将 List<String> tags 转为 Map<String, List<String>>
+  static Map<String, List<String>> _tagsListToMap(List<String> tags) {
+    if (tags.isEmpty) return {};
+    return {"tags": tags};
   }
 
   @override
@@ -599,28 +661,56 @@ class ComicPageLogic<T extends Object> extends StateController {
   int colorIndex = 0;
   bool? favoriteOnPlatform;
 
+  /// 网络加载失败时的信息（有本地数据时网络失败用 toast 展示，不阻塞页面）
+  String? networkMessage;
+
+  /// 由 [BaseComicPage] 在首次构建时注入，指向子类的 loadLocalData 方法
+  Future<T?> Function()? loadLocalData;
+
   void get(Future<Res<T>> Function() loadData,
       Future<bool> Function(T) loadFavorite, String Function() getId) async {
+    // ======== 阶段1：加载本地数据和历史 ========
+    history = await HistoryManager().find(getId());
+
+    if (loadLocalData != null) {
+      var local = await loadLocalData!();
+      if (local != null) {
+        data = local;
+        favorite = await loadFavorite(local);
+        loading = false;
+        update();
+      }
+    }
+
+    // ======== 阶段2：加载网络数据 ========
     var [res, _] = await Future.wait(
         [loadData(), Future.delayed(const Duration(milliseconds: 300))]);
+
     if (res.error) {
-      message = res.errorMessage;
-      if (message == "Exit") {
-        loading = false;
-        return;
+      if (data == null) {
+        message = res.errorMessage;
+        if (message == "Exit") {
+          loading = false;
+          return;
+        }
+      } else {
+        networkMessage = res.errorMessage;
       }
     } else {
       data = res.data;
       favorite = await loadFavorite(res.data);
+      message = null;
+      networkMessage = null;
     }
+
     loading = false;
-    history = await HistoryManager().find(getId());
     update();
   }
 
   void refresh_() {
     data = null;
     message = null;
+    networkMessage = null;
     loading = true;
     update();
   }
@@ -729,6 +819,11 @@ abstract class BaseComicPage<T extends Object> extends StatelessWidget {
 
   Future<bool> loadFavorite(T data);
 
+  /// 从本地数据源加载漫画信息。
+  /// 返回非 null 时，页面将立即渲染本地数据，同时后台继续加载网络数据。
+  /// 默认返回 null（保持现有行为，不启用本地加载）。
+  Future<T?> loadLocalData() async => null;
+
   /// used for history
   String get id;
 
@@ -791,6 +886,7 @@ abstract class BaseComicPage<T extends Object> extends StatelessWidget {
             _logic.width = constraints.maxWidth;
             _logic.height = constraints.maxHeight;
             if (logic.loading) {
+              logic.loadLocalData = loadLocalData;
               logic.get(loadData, loadFavorite, () => id);
               return buildLoading(context);
             } else if (logic.message != null) {
@@ -802,6 +898,14 @@ abstract class BaseComicPage<T extends Object> extends StatelessWidget {
               _logic.thumbnailsData ??= thumbnailsCreator;
               logic.controller.removeListener(scrollListener);
               logic.controller.addListener(scrollListener);
+
+              if (logic.networkMessage != null) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  showToast(message: logic.networkMessage!);
+                  logic.networkMessage = null;
+                });
+              }
+
               return SmoothCustomScrollView(
                 controller: logic.controller,
                 slivers: [

--- a/lib/pages/comic_page.dart
+++ b/lib/pages/comic_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:pica_comic/base.dart';
 import 'package:pica_comic/comic_source/comic_source.dart';
+import 'package:pica_comic/network/custom_download_model.dart';
 import 'package:pica_comic/components/comment.dart';
 import 'package:pica_comic/components/components.dart';
 import 'package:pica_comic/components/select_download_eps.dart';
@@ -18,7 +19,6 @@ import 'package:pica_comic/foundation/log.dart';
 import 'package:pica_comic/foundation/stack.dart' as stack;
 import 'package:pica_comic/foundation/ui_mode.dart';
 import 'package:pica_comic/network/base_comic.dart';
-import 'package:pica_comic/network/custom_download_model.dart';
 import 'package:pica_comic/network/download.dart';
 import 'package:pica_comic/network/res.dart';
 import 'package:pica_comic/pages/favorites/local_favorites.dart';
@@ -123,6 +123,64 @@ class _ComicPageImpl extends BaseComicPage<ComicInfoData> {
   }
 
   @override
+  Future<ComicInfoData?> loadLocalData() async {
+    final downloadId = DownloadManager().generateId(sourceKey, id);
+
+    // 优先级1：已下载的记录
+    DownloadedItem? downloaded;
+    try {
+      if (DownloadManager().isExists(downloadId)) {
+        downloaded = await DownloadManager().getComicOrNull(downloadId);
+      }
+    } catch (_) {}
+
+    if (downloaded != null) {
+      return ComicInfoData(
+        downloaded.name,
+        downloaded.subTitle,
+        downloaded.cover,
+        null,                            // description: 本地无
+        _tagsListToMap(downloaded.tags), // tags: 从下载记录恢复
+        downloaded is CustomDownloadedItem
+            ? (downloaded as CustomDownloadedItem).chapters
+            : null,                      // chapters: 仅 CustomDownloadedItem 有
+        null,                            // thumbnails: 本地无
+        null,                            // thumbnailLoader: 本地无
+        0,
+        null,                            // suggestions: 本地无
+        sourceKey,
+        id,
+      );
+    }
+
+    // 优先级2：阅读历史（title、cover、subtitle 已在 get() 中查询，存在 _logic.history 中）
+    final h = _logic.history;
+    if (h != null && h.title.isNotEmpty) {
+      return ComicInfoData(
+        h.title,
+        h.subtitle,
+        h.cover,
+        null,                            // description
+        {},                              // tags: 无
+        null,                            // chapters: 无
+        null,                            // thumbnails
+        null,                            // thumbnailLoader
+        0,
+        null,                            // suggestions
+        sourceKey,
+        id,
+      );
+    }
+    return null;
+  }
+
+  /// 辅助方法：将 List<String> tags 转为 Map<String, List<String>>
+  static Map<String, List<String>> _tagsListToMap(List<String> tags) {
+    if (tags.isEmpty) return {};
+    return {"tags": tags};
+  }
+
+  @override
   EpsData? get eps {
     if (data!.chapters != null && data!.chapters!.isNotEmpty) {
       return EpsData(
@@ -161,68 +219,12 @@ class _ComicPageImpl extends BaseComicPage<ComicInfoData> {
 
   @override
   Future<bool> loadFavorite(ComicInfoData data) async {
+    // 平台收藏状态（网络返回），无平台收藏功能的源此值为 null
     bool platformFavorite = data.isFavorite ?? false;
+    // 本地收藏状态（SQLite），isExist() 只按 target 匹配，不受 FavoriteType 不一致影响
     bool localFavorite = LocalFavoritesManager().isExist(id);
+    // 网络或本地，任意一边为 true → 显示"已收藏"
     return platformFavorite || localFavorite;
-  }
-
-  @override
-  Future<ComicInfoData?> loadLocalData() async {
-    final downloadId = DownloadManager().generateId(sourceKey, id);
-
-    // 优先级1：已下载的记录（数据最完整：title、cover、tags、可能包含 chapters）
-    DownloadedItem? downloaded;
-    try {
-      if (DownloadManager().isExists(downloadId)) {
-        downloaded = await DownloadManager().getComicOrNull(downloadId);
-      }
-    } catch (_) {}
-
-    if (downloaded != null) {
-      return ComicInfoData(
-        downloaded.name,
-        downloaded.subTitle,
-        downloaded.cover,
-        null,                            // description: 本地无
-        _tagsListToMap(downloaded.tags), // tags: 从下载记录恢复
-        downloaded is CustomDownloadedItem
-            ? (downloaded as CustomDownloadedItem).chapters
-            : null,                      // chapters: 仅 CustomDownloadedItem 有
-        null,                            // thumbnails: 本地无
-        null,                            // thumbnailLoader: 本地无
-        0,
-        null,                            // suggestions: 本地无
-        sourceKey,
-        id,
-      );
-    }
-
-    // 优先级2：阅读历史（已在 get() 阶段1中查询，存在 _logic.history 中）
-    final h = _logic.history;
-    if (h != null && h.title.isNotEmpty) {
-      return ComicInfoData(
-        h.title,
-        h.subtitle,
-        h.cover,
-        null,                            // description
-        {},                              // tags: 无
-        null,                            // chapters: 无
-        null,                            // thumbnails
-        null,                            // thumbnailLoader
-        0,
-        null,                            // suggestions
-        sourceKey,
-        id,
-      );
-    }
-
-    return null;
-  }
-
-  /// 辅助方法：将 List<String> tags 转为 Map<String, List<String>>
-  static Map<String, List<String>> _tagsListToMap(List<String> tags) {
-    if (tags.isEmpty) return {};
-    return {"tags": tags};
   }
 
   @override
@@ -660,52 +662,54 @@ class ComicPageLogic<T extends Object> extends StateController {
   bool showFullEps = false;
   int colorIndex = 0;
   bool? favoriteOnPlatform;
+  String? networkMessage;/// 网络加载失败时的信息（有本地数据时网络失败用 toast 展示，不阻塞页面）
 
-  /// 网络加载失败时的信息（有本地数据时网络失败用 toast 展示，不阻塞页面）
-  String? networkMessage;
 
-  /// 由 [BaseComicPage] 在首次构建时注入，指向子类的 loadLocalData 方法
-  Future<T?> Function()? loadLocalData;
+  Future<T?> Function()? loadLocalData;/// 由 [BaseComicPage] 在首次构建时注入，指向子类的 loadLocalData 方法
 
-  void get(Future<Res<T>> Function() loadData,
-      Future<bool> Function(T) loadFavorite, String Function() getId) async {
-    // ======== 阶段1：加载本地数据和历史 ========
-    history = await HistoryManager().find(getId());
+void get(Future<Res<T>> Function() loadData,
+    Future<bool> Function(T) loadFavorite, String Function() getId) async {
+  // ======== 阶段1：加载本地数据和历史 ========
+  history = await HistoryManager().find(getId());
 
-    if (loadLocalData != null) {
-      var local = await loadLocalData!();
-      if (local != null) {
-        data = local;
-        favorite = await loadFavorite(local);
-        loading = false;
-        update();
-      }
+  if (loadLocalData != null) {
+    var local = await loadLocalData!();
+    if (local != null) {
+      // 本地有数据，立即展示页面
+      data = local;
+      favorite = await loadFavorite(local);
+      loading = false;
+      update();  // ← 页面立即渲染，看到标题、封面、操作按钮
     }
+  }
 
-    // ======== 阶段2：加载网络数据 ========
-    var [res, _] = await Future.wait(
-        [loadData(), Future.delayed(const Duration(milliseconds: 300))]);
+  // ======== 阶段2：加载网络数据 ========
+  var [res, _] = await Future.wait(
+      [loadData(), Future.delayed(const Duration(milliseconds: 300))]);
 
-    if (res.error) {
-      if (data == null) {
-        message = res.errorMessage;
-        if (message == "Exit") {
-          loading = false;
-          return;
-        }
-      } else {
-        networkMessage = res.errorMessage;
+  if (res.error) {
+    if (data == null) {
+      // 无本地数据 且 网络失败 → 显示错误（现有行为保持）
+      message = res.errorMessage;
+      if (message == "Exit") {
+        loading = false;
+        return;
       }
     } else {
-      data = res.data;
-      favorite = await loadFavorite(res.data);
-      message = null;
-      networkMessage = null;
+      // 有本地数据 但 网络失败 → 保留本地数据，仅记录错误
+      networkMessage = res.errorMessage;
     }
-
-    loading = false;
-    update();
+  } else {
+    // 网络成功 → 用完整数据替换本地数据
+    data = res.data;
+    favorite = await loadFavorite(res.data);
+    message = null;
+    networkMessage = null;
   }
+
+  loading = false;
+  update();
+}
 
   void refresh_() {
     data = null;
@@ -819,11 +823,6 @@ abstract class BaseComicPage<T extends Object> extends StatelessWidget {
 
   Future<bool> loadFavorite(T data);
 
-  /// 从本地数据源加载漫画信息。
-  /// 返回非 null 时，页面将立即渲染本地数据，同时后台继续加载网络数据。
-  /// 默认返回 null（保持现有行为，不启用本地加载）。
-  Future<T?> loadLocalData() async => null;
-
   /// used for history
   String get id;
 
@@ -898,14 +897,12 @@ abstract class BaseComicPage<T extends Object> extends StatelessWidget {
               _logic.thumbnailsData ??= thumbnailsCreator;
               logic.controller.removeListener(scrollListener);
               logic.controller.addListener(scrollListener);
-
               if (logic.networkMessage != null) {
-                WidgetsBinding.instance.addPostFrameCallback((_) {
-                  showToast(message: logic.networkMessage!);
-                  logic.networkMessage = null;
-                });
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                      showToast(message: logic.networkMessage!);
+                      logic.networkMessage = null;
+                  });
               }
-
               return SmoothCustomScrollView(
                 controller: logic.controller,
                 slivers: [
@@ -1785,6 +1782,10 @@ abstract class BaseComicPage<T extends Object> extends StatelessWidget {
       );
     }
   }
+  /// 从本地数据源加载漫画信息。
+  /// 返回非 null 时，页面将立即渲染本地数据，同时后台继续加载网络数据。
+  /// 默认返回 null（保持现有行为，不启用本地加载）。
+  Future<T?> loadLocalData() async => null;
 }
 
 class FavoriteComicWidget extends StatefulWidget {

--- a/lib/pages/comic_page.dart
+++ b/lib/pages/comic_page.dart
@@ -19,6 +19,7 @@ import 'package:pica_comic/foundation/log.dart';
 import 'package:pica_comic/foundation/stack.dart' as stack;
 import 'package:pica_comic/foundation/ui_mode.dart';
 import 'package:pica_comic/network/base_comic.dart';
+import 'package:pica_comic/network/download_model.dart';
 import 'package:pica_comic/network/download.dart';
 import 'package:pica_comic/network/res.dart';
 import 'package:pica_comic/pages/favorites/local_favorites.dart';

--- a/lib/pages/comic_page.dart
+++ b/lib/pages/comic_page.dart
@@ -139,7 +139,7 @@ class _ComicPageImpl extends BaseComicPage<ComicInfoData> {
       return ComicInfoData(
         downloaded.name,
         downloaded.subTitle,
-        downloaded.cover,
+        _logic.history?.cover ?? '',
         null,                            // description: 本地无
         _tagsListToMap(downloaded.tags), // tags: 从下载记录恢复
         downloaded is CustomDownloadedItem

--- a/lib/pages/comic_page.dart
+++ b/lib/pages/comic_page.dart
@@ -822,6 +822,8 @@ abstract class BaseComicPage<T extends Object> extends StatelessWidget {
   @nonVirtual
   set favorite(bool f) => _logic.favorite = f;
 
+  History? get pageHistory => _logic.history;
+
   Future<bool> loadFavorite(T data);
 
   /// used for history

--- a/lib/pages/comic_page.dart
+++ b/lib/pages/comic_page.dart
@@ -183,15 +183,15 @@ class _ComicPageImpl extends BaseComicPage<ComicInfoData> {
         downloaded.name,
         downloaded.subTitle,
         downloaded.cover,
-        null,
-        _tagsListToMap(downloaded.tags),
+        null,                            // description: 本地无
+        _tagsListToMap(downloaded.tags), // tags: 从下载记录恢复
         downloaded is CustomDownloadedItem
             ? (downloaded as CustomDownloadedItem).chapters
-            : null,
-        null,
-        null,
+            : null,                      // chapters: 仅 CustomDownloadedItem 有
+        null,                            // thumbnails: 本地无
+        null,                            // thumbnailLoader: 本地无
         0,
-        null,
+        null,                            // suggestions: 本地无
         sourceKey,
         id,
       );
@@ -204,13 +204,13 @@ class _ComicPageImpl extends BaseComicPage<ComicInfoData> {
         h.title,
         h.subtitle,
         h.cover,
-        null,
-        {},
-        null,
-        null,
-        null,
+        null,                            // description
+        {},                              // tags: 无
+        null,                            // chapters: 无
+        null,                            // thumbnails
+        null,                            // thumbnailLoader
         0,
-        null,
+        null,                            // suggestions
         sourceKey,
         id,
       );

--- a/lib/pages/ehentai/eh_gallery_page.dart
+++ b/lib/pages/ehentai/eh_gallery_page.dart
@@ -54,13 +54,40 @@ class EhGalleryPage extends BaseComicPage<Gallery> {
   
   @override
   Future<Gallery?> loadLocalData() async {
+    String title, cover, subTitle;
+    bool found = false;
     final h = pageHistory;
-    if (h == null || h.title.isEmpty) return null;
+    if (h != null && h.title.isNotEmpty) {
+      title = h.title; cover = h.cover; subTitle = h.subtitle; found = true;
+    }
+    if (!found) {
+      try {
+        final dlId = DownloadManager().generateId(sourceKey, id);
+        if (DownloadManager().isExists(dlId)) {
+          final dl = await DownloadManager().getComicOrNull(dlId);
+          if (dl != null && dl.name.isNotEmpty) {
+            title = dl.name; subTitle = dl.subTitle;
+            cover = 'file://${DownloadManager().path}/${DownloadManager().getDirectory(dlId)}/cover.jpg';
+            found = true;
+          }
+        }
+      } catch (_) {}
+    }
+    if (!found) {
+      try {
+        final folders = await LocalFavoritesManager().find(id, const FavoriteType(1));
+        if (folders.isNotEmpty) {
+          final item = LocalFavoritesManager().getComic(folders.first, id, const FavoriteType(1));
+          title = item.name; subTitle = item.author; cover = item.coverPath; found = true;
+        }
+      } catch (_) {}
+    }
+    if (!found) return null;
     try {
       return Gallery.fromJson({
-        "title": h.title, "subTitle": h.subtitle,
-        "type": "", "time": "", "uploader": h.subtitle,
-        "stars": 0.0, "rating": null, "coverPath": h.cover,
+        "title": title, "subTitle": subTitle,
+        "type": "", "time": "", "uploader": subTitle,
+        "stars": 0.0, "rating": null, "coverPath": cover,
         "tags": <String, List<String>>{}, "favorite": false,
         "link": id, "maxPage": "0", "pageSize": 20,
         "ext": "jpg", "width": 100

--- a/lib/pages/ehentai/eh_gallery_page.dart
+++ b/lib/pages/ehentai/eh_gallery_page.dart
@@ -54,7 +54,7 @@ class EhGalleryPage extends BaseComicPage<Gallery> {
   
   @override
   Future<Gallery?> loadLocalData() async {
-    String title, cover, subTitle;
+    String title = '', cover = '', subTitle = '';
     bool found = false;
     final h = pageHistory;
     if (h != null && h.title.isNotEmpty) {

--- a/lib/pages/ehentai/eh_gallery_page.dart
+++ b/lib/pages/ehentai/eh_gallery_page.dart
@@ -51,7 +51,24 @@ class EhGalleryPage extends BaseComicPage<Gallery> {
           ),
         );
       };
+  
+  @override
+  Future<Gallery?> loadLocalData() async {
+    final h = _logic.history;
+    if (h == null || h.title.isEmpty) return null;
+    try {
+      return Gallery.fromJson({
+        "title": h.title, "subTitle": h.subtitle,
+        "type": "", "time": "", "uploader": h.subtitle,
+        "stars": 0.0, "rating": null, "coverPath": h.cover,
+        "tags": <String, List<String>>{}, "favorite": false,
+        "link": id, "maxPage": "0", "pageSize": 20,
+        "ext": "jpg", "width": 100
+      });
+    } catch (_) { return null; }
+  }
 
+  
   @override
   String? get cover => (comicCover ?? data?.coverPath)
       ?.replaceFirst("s.exhentai.org", "ehgt.org");

--- a/lib/pages/ehentai/eh_gallery_page.dart
+++ b/lib/pages/ehentai/eh_gallery_page.dart
@@ -54,7 +54,7 @@ class EhGalleryPage extends BaseComicPage<Gallery> {
   
   @override
   Future<Gallery?> loadLocalData() async {
-    final h = _logic.history;
+    final h = pageHistory;
     if (h == null || h.title.isEmpty) return null;
     try {
       return Gallery.fromJson({

--- a/lib/pages/hitomi/hitomi_comic_page.dart
+++ b/lib/pages/hitomi/hitomi_comic_page.dart
@@ -213,13 +213,40 @@ class HitomiComicPage extends BaseComicPage<HitomiComic> {
 
   @override
   Future<HitomiComic?> loadLocalData() async {
+    String title, cover, subTitle;
+    bool found = false;
     final h = pageHistory;
-    if (h == null || h.title.isEmpty) return null;
+    if (h != null && h.title.isNotEmpty) {
+      title = h.title; cover = h.cover; subTitle = h.subtitle; found = true;
+    }
+    if (!found) {
+      try {
+        final dlId = DownloadManager().generateId(sourceKey, id);
+        if (DownloadManager().isExists(dlId)) {
+          final dl = await DownloadManager().getComicOrNull(dlId);
+          if (dl != null && dl.name.isNotEmpty) {
+            title = dl.name; subTitle = dl.subTitle;
+            cover = 'file://${DownloadManager().path}/${DownloadManager().getDirectory(dlId)}/cover.jpg';
+            found = true;
+          }
+        }
+      } catch (_) {}
+    }
+    if (!found) {
+      try {
+        final folders = await LocalFavoritesManager().find(id, const FavoriteType(3));
+        if (folders.isNotEmpty) {
+          final item = LocalFavoritesManager().getComic(folders.first, id, const FavoriteType(3));
+          title = item.name; subTitle = item.author; cover = item.coverPath; found = true;
+        }
+      } catch (_) {}
+    }
+    if (!found) return null;
     try {
       return HitomiComic(
-        link, h.title, <int>[], "", <String>[h.subtitle],
+        link, title, <int>[], "", <String>[subTitle],
         "", <Tag>[], <Tag>[], <Tag>[], "",
-        <HitomiFile>[], <String>[], h.cover,
+        <HitomiFile>[], <String>[], cover,
       );
     } catch (_) { return null; }
   }

--- a/lib/pages/hitomi/hitomi_comic_page.dart
+++ b/lib/pages/hitomi/hitomi_comic_page.dart
@@ -210,6 +210,19 @@ class HitomiComicPage extends BaseComicPage<HitomiComic> {
 
   @override
   String get sourceKey => "hitomi";
+
+  @override
+  Future<HitomiComic?> loadLocalData() async {
+    final h = _logic.history;
+    if (h == null || h.title.isEmpty) return null;
+    try {
+      return HitomiComic(
+        link, h.title, <int>[], "", <String>[h.subtitle],
+        "", <Tag>[], <Tag>[], <Tag>[], "",
+        <HitomiFile>[], <String>[], h.cover,
+      );
+    } catch (_) { return null; }
+  }
 }
 
 void _downloadComic(

--- a/lib/pages/hitomi/hitomi_comic_page.dart
+++ b/lib/pages/hitomi/hitomi_comic_page.dart
@@ -213,7 +213,7 @@ class HitomiComicPage extends BaseComicPage<HitomiComic> {
 
   @override
   Future<HitomiComic?> loadLocalData() async {
-    String title, cover, subTitle;
+    String title = '', cover = '', subTitle = '';
     bool found = false;
     final h = pageHistory;
     if (h != null && h.title.isNotEmpty) {

--- a/lib/pages/hitomi/hitomi_comic_page.dart
+++ b/lib/pages/hitomi/hitomi_comic_page.dart
@@ -213,7 +213,7 @@ class HitomiComicPage extends BaseComicPage<HitomiComic> {
 
   @override
   Future<HitomiComic?> loadLocalData() async {
-    final h = _logic.history;
+    final h = pageHistory;
     if (h == null || h.title.isEmpty) return null;
     try {
       return HitomiComic(

--- a/lib/pages/htmanga/ht_comic_page.dart
+++ b/lib/pages/htmanga/ht_comic_page.dart
@@ -180,7 +180,7 @@ class HtComicPage extends BaseComicPage<HtComicInfo> {
 
   @override
   Future<HtComicInfo?> loadLocalData() async {
-    String title, cover, subTitle;
+    String title = '', cover = '', subTitle = '';
     bool found = false;
     final h = pageHistory;
     if (h != null && h.title.isNotEmpty) {

--- a/lib/pages/htmanga/ht_comic_page.dart
+++ b/lib/pages/htmanga/ht_comic_page.dart
@@ -177,6 +177,20 @@ class HtComicPage extends BaseComicPage<HtComicInfo> {
 
   @override
   String get sourceKey => 'htmanga';
+
+  @override
+  Future<HtComicInfo?> loadLocalData() async {
+    final h = _logic.history;
+    if (h == null || h.title.isEmpty) return null;
+    try {
+      return HtComicInfo.fromJson({
+        "id": id, "coverPath": h.cover, "name": h.title,
+        "category": "", "pages": 0, "tags": <String, String>{},
+        "description": "", "uploader": h.subtitle,
+        "avatar": "", "uploadNum": 0
+      });
+    } catch (_) { return null; }
+  }
 }
 
 class HtComicPageLogic extends StateController {

--- a/lib/pages/htmanga/ht_comic_page.dart
+++ b/lib/pages/htmanga/ht_comic_page.dart
@@ -180,13 +180,40 @@ class HtComicPage extends BaseComicPage<HtComicInfo> {
 
   @override
   Future<HtComicInfo?> loadLocalData() async {
+    String title, cover, subTitle;
+    bool found = false;
     final h = pageHistory;
-    if (h == null || h.title.isEmpty) return null;
+    if (h != null && h.title.isNotEmpty) {
+      title = h.title; cover = h.cover; subTitle = h.subtitle; found = true;
+    }
+    if (!found) {
+      try {
+        final dlId = DownloadManager().generateId(sourceKey, id);
+        if (DownloadManager().isExists(dlId)) {
+          final dl = await DownloadManager().getComicOrNull(dlId);
+          if (dl != null && dl.name.isNotEmpty) {
+            title = dl.name; subTitle = dl.subTitle;
+            cover = 'file://${DownloadManager().path}/${DownloadManager().getDirectory(dlId)}/cover.jpg';
+            found = true;
+          }
+        }
+      } catch (_) {}
+    }
+    if (!found) {
+      try {
+        final folders = await LocalFavoritesManager().find(id, const FavoriteType(4));
+        if (folders.isNotEmpty) {
+          final item = LocalFavoritesManager().getComic(folders.first, id, const FavoriteType(4));
+          title = item.name; subTitle = item.author; cover = item.coverPath; found = true;
+        }
+      } catch (_) {}
+    }
+    if (!found) return null;
     try {
       return HtComicInfo.fromJson({
-        "id": id, "coverPath": h.cover, "name": h.title,
+        "id": id, "coverPath": cover, "name": title,
         "category": "", "pages": 0, "tags": <String, String>{},
-        "description": "", "uploader": h.subtitle,
+        "description": "", "uploader": subTitle,
         "avatar": "", "uploadNum": 0
       });
     } catch (_) { return null; }

--- a/lib/pages/htmanga/ht_comic_page.dart
+++ b/lib/pages/htmanga/ht_comic_page.dart
@@ -180,7 +180,7 @@ class HtComicPage extends BaseComicPage<HtComicInfo> {
 
   @override
   Future<HtComicInfo?> loadLocalData() async {
-    final h = _logic.history;
+    final h = pageHistory;
     if (h == null || h.title.isEmpty) return null;
     try {
       return HtComicInfo.fromJson({

--- a/lib/pages/jm/jm_comic_page.dart
+++ b/lib/pages/jm/jm_comic_page.dart
@@ -203,12 +203,38 @@ class JmComicPage extends BaseComicPage<JmComicInfo> {
 
   @override
   Future<JmComicInfo?> loadLocalData() async {
+    String title, cover, subTitle;
+    bool found = false;
     final h = pageHistory;
-    if (h == null || h.title.isEmpty) return null;
+    if (h != null && h.title.isNotEmpty) {
+      title = h.title; cover = h.cover; subTitle = h.subtitle; found = true;
+    }
+    if (!found) {
+      try {
+        final dlId = DownloadManager().generateId(sourceKey, id);
+        if (DownloadManager().isExists(dlId)) {
+          final dl = await DownloadManager().getComicOrNull(dlId);
+          if (dl != null && dl.name.isNotEmpty) {
+            title = dl.name; subTitle = dl.subTitle;
+            cover = 'file://${DownloadManager().path}/${DownloadManager().getDirectory(dlId)}/cover.jpg';
+            found = true;
+          }
+        }
+      } catch (_) {}
+    }
+    if (!found) {
+      try {
+        final folders = await LocalFavoritesManager().find(id, const FavoriteType(2));
+        if (folders.isNotEmpty) {
+          final item = LocalFavoritesManager().getComic(folders.first, id, const FavoriteType(2));
+          title = item.name; subTitle = item.author; cover = item.coverPath; found = true;
+        }
+      } catch (_) {}
+    }
+    if (!found) return null;
     try {
       return JmComicInfo.fromMap({
-        "name": h.title, "id": id,
-        "author": <String>[h.subtitle],
+        "name": title, "id": id, "author": <String>[subTitle],
         "description": "", "series": <String, String>{},
         "tags": <String>[], "works": <String>[],
         "actors": <String>[], "epNames": <String>[]

--- a/lib/pages/jm/jm_comic_page.dart
+++ b/lib/pages/jm/jm_comic_page.dart
@@ -203,7 +203,7 @@ class JmComicPage extends BaseComicPage<JmComicInfo> {
 
   @override
   Future<JmComicInfo?> loadLocalData() async {
-    final h = _logic.history;
+    final h = pageHistory;
     if (h == null || h.title.isEmpty) return null;
     try {
       return JmComicInfo.fromMap({

--- a/lib/pages/jm/jm_comic_page.dart
+++ b/lib/pages/jm/jm_comic_page.dart
@@ -203,7 +203,7 @@ class JmComicPage extends BaseComicPage<JmComicInfo> {
 
   @override
   Future<JmComicInfo?> loadLocalData() async {
-    String title, cover, subTitle;
+    String title = '', cover = '', subTitle = '';
     bool found = false;
     final h = pageHistory;
     if (h != null && h.title.isNotEmpty) {

--- a/lib/pages/jm/jm_comic_page.dart
+++ b/lib/pages/jm/jm_comic_page.dart
@@ -199,6 +199,22 @@ class JmComicPage extends BaseComicPage<JmComicInfo> {
 
   @override
   String get sourceKey => "jm";
+
+
+  @override
+  Future<JmComicInfo?> loadLocalData() async {
+    final h = _logic.history;
+    if (h == null || h.title.isEmpty) return null;
+    try {
+      return JmComicInfo.fromMap({
+        "name": h.title, "id": id,
+        "author": <String>[h.subtitle],
+        "description": "", "series": <String, String>{},
+        "tags": <String>[], "works": <String>[],
+        "actors": <String>[], "epNames": <String>[]
+      });
+    } catch (_) { return null; }
+  }
 }
 
 void downloadComic(JmComicInfo comic, BuildContext context) async {

--- a/lib/pages/nhentai/comic_page.dart
+++ b/lib/pages/nhentai/comic_page.dart
@@ -247,12 +247,39 @@ class NhentaiComicPage extends BaseComicPage<NhentaiComic> {
   
   @override
   Future<NhentaiComic?> loadLocalData() async {
+    String title, cover, subTitle;
+    bool found = false;
     final h = pageHistory;
-    if (h == null || h.title.isEmpty) return null;
+    if (h != null && h.title.isNotEmpty) {
+      title = h.title; cover = h.cover; subTitle = h.subtitle; found = true;
+    }
+    if (!found) {
+      try {
+        final dlId = DownloadManager().generateId(sourceKey, id);
+        if (DownloadManager().isExists(dlId)) {
+          final dl = await DownloadManager().getComicOrNull(dlId);
+          if (dl != null && dl.name.isNotEmpty) {
+            title = dl.name; subTitle = dl.subTitle;
+            cover = 'file://${DownloadManager().path}/${DownloadManager().getDirectory(dlId)}/cover.jpg';
+            found = true;
+          }
+        }
+      } catch (_) {}
+    }
+    if (!found) {
+      try {
+        final folders = await LocalFavoritesManager().find(id, const FavoriteType(6));
+        if (folders.isNotEmpty) {
+          final item = LocalFavoritesManager().getComic(folders.first, id, const FavoriteType(6));
+          title = item.name; subTitle = item.author; cover = item.coverPath; found = true;
+        }
+      } catch (_) {}
+    }
+    if (!found) return null;
     try {
       return NhentaiComic.fromMap({
-        "id": id, "title": h.title,
-        "subTitle": h.subtitle, "cover": h.cover,
+        "id": id, "title": title,
+        "subTitle": subTitle, "cover": cover,
       });
     } catch (_) { return null; }
   }

--- a/lib/pages/nhentai/comic_page.dart
+++ b/lib/pages/nhentai/comic_page.dart
@@ -244,4 +244,16 @@ class NhentaiComicPage extends BaseComicPage<NhentaiComic> {
 
   @override
   String get sourceKey => 'nhentai';
+  
+  @override
+  Future<NhentaiComic?> loadLocalData() async {
+    final h = _logic.history;
+    if (h == null || h.title.isEmpty) return null;
+    try {
+      return NhentaiComic.fromMap({
+        "id": id, "title": h.title,
+        "subTitle": h.subtitle, "cover": h.cover,
+      });
+    } catch (_) { return null; }
+  }
 }

--- a/lib/pages/nhentai/comic_page.dart
+++ b/lib/pages/nhentai/comic_page.dart
@@ -247,7 +247,7 @@ class NhentaiComicPage extends BaseComicPage<NhentaiComic> {
   
   @override
   Future<NhentaiComic?> loadLocalData() async {
-    final h = _logic.history;
+    final h = pageHistory;
     if (h == null || h.title.isEmpty) return null;
     try {
       return NhentaiComic.fromMap({

--- a/lib/pages/nhentai/comic_page.dart
+++ b/lib/pages/nhentai/comic_page.dart
@@ -247,7 +247,7 @@ class NhentaiComicPage extends BaseComicPage<NhentaiComic> {
   
   @override
   Future<NhentaiComic?> loadLocalData() async {
-    String title, cover, subTitle;
+    String title = '', cover = '', subTitle = '';
     bool found = false;
     final h = pageHistory;
     if (h != null && h.title.isNotEmpty) {

--- a/lib/pages/picacg/comic_page.dart
+++ b/lib/pages/picacg/comic_page.dart
@@ -81,7 +81,7 @@ class PicacgComicPage extends BaseComicPage<ComicItem> {
         "description": "", "author": subTitle, "chineseTeam": "",
         "categories": <String>[], "tags": <String>[],
         "likes": 0, "comments": 0, "isLiked": false, "isFavourite": false,
-        "epsCount": 0, "time": "", "pagesCount": 0
+        "epsCount": 0, "time": "0000-00-00 00:00:00", "pagesCount": 0
       });
     } catch (_) { return null; }
   }

--- a/lib/pages/picacg/comic_page.dart
+++ b/lib/pages/picacg/comic_page.dart
@@ -41,19 +41,44 @@ class PicacgComicPage extends BaseComicPage<ComicItem> {
   @override
   bool get isLiked => data!.isLiked;
   
-  @override
+@override
   Future<ComicItem?> loadLocalData() async {
+    String title, cover, subTitle;
+    bool found = false;
     final h = pageHistory;
-    if (h == null || h.title.isEmpty) return null;
+    if (h != null && h.title.isNotEmpty) {
+      title = h.title; cover = h.cover; subTitle = h.subtitle; found = true;
+    }
+    if (!found) {
+      try {
+        final dlId = DownloadManager().generateId(sourceKey, id);
+        if (DownloadManager().isExists(dlId)) {
+          final dl = await DownloadManager().getComicOrNull(dlId);
+          if (dl != null && dl.name.isNotEmpty) {
+            title = dl.name; subTitle = dl.subTitle;
+            cover = 'file://${DownloadManager().path}/${DownloadManager().getDirectory(dlId)}/cover.jpg';
+            found = true;
+          }
+        }
+      } catch (_) {}
+    }
+    if (!found) {
+      try {
+        final folders = await LocalFavoritesManager().find(id, const FavoriteType(0));
+        if (folders.isNotEmpty) {
+          final item = LocalFavoritesManager().getComic(folders.first, id, const FavoriteType(0));
+          title = item.name; subTitle = item.author; cover = item.coverPath; found = true;
+        }
+      } catch (_) {}
+    }
+    if (!found) return null;
     try {
       return ComicItem.fromJson({
         "creator": {"id": "", "title": "", "email": "", "name": "",
                      "level": 0, "exp": 0, "avatarUrl": "",
                      "frameUrl": null, "isPunched": null, "slogan": null},
-        "id": id,
-        "title": h.title,
-        "thumbUrl": h.cover,
-        "description": "", "author": h.subtitle, "chineseTeam": "",
+        "id": id, "title": title, "thumbUrl": cover,
+        "description": "", "author": subTitle, "chineseTeam": "",
         "categories": <String>[], "tags": <String>[],
         "likes": 0, "comments": 0, "isLiked": false, "isFavourite": false,
         "epsCount": 0, "time": "", "pagesCount": 0

--- a/lib/pages/picacg/comic_page.dart
+++ b/lib/pages/picacg/comic_page.dart
@@ -41,7 +41,7 @@ class PicacgComicPage extends BaseComicPage<ComicItem> {
   @override
   bool get isLiked => data!.isLiked;
   
-@override
+  @override
   Future<ComicItem?> loadLocalData() async {
     String title = '', cover = '', subTitle = '';
     bool found = false;

--- a/lib/pages/picacg/comic_page.dart
+++ b/lib/pages/picacg/comic_page.dart
@@ -40,7 +40,28 @@ class PicacgComicPage extends BaseComicPage<ComicItem> {
 
   @override
   bool get isLiked => data!.isLiked;
+  
+  @override
+  Future<ComicItem?> loadLocalData() async {
+    final h = _logic.history;
+    if (h == null || h.title.isEmpty) return null;
+    try {
+      return ComicItem.fromJson({
+        "creator": {"id": "", "title": "", "email": "", "name": "",
+                     "level": 0, "exp": 0, "avatarUrl": "",
+                     "frameUrl": null, "isPunched": null, "slogan": null},
+        "id": id,
+        "title": h.title,
+        "thumbUrl": h.cover,
+        "description": "", "author": h.subtitle, "chineseTeam": "",
+        "categories": <String>[], "tags": <String>[],
+        "likes": 0, "comments": 0, "isLiked": false, "isFavourite": false,
+        "epsCount": 0, "time": "", "pagesCount": 0
+      });
+    } catch (_) { return null; }
+  }
 
+  
   @override
   void openFavoritePanel() {
     favoriteComic(FavoriteComicWidget(

--- a/lib/pages/picacg/comic_page.dart
+++ b/lib/pages/picacg/comic_page.dart
@@ -43,7 +43,7 @@ class PicacgComicPage extends BaseComicPage<ComicItem> {
   
   @override
   Future<ComicItem?> loadLocalData() async {
-    final h = _logic.history;
+    final h = pageHistory;
     if (h == null || h.title.isEmpty) return null;
     try {
       return ComicItem.fromJson({

--- a/lib/pages/picacg/comic_page.dart
+++ b/lib/pages/picacg/comic_page.dart
@@ -43,7 +43,7 @@ class PicacgComicPage extends BaseComicPage<ComicItem> {
   
 @override
   Future<ComicItem?> loadLocalData() async {
-    String title, cover, subTitle;
+    String title = '', cover = '', subTitle = '';
     bool found = false;
     final h = pageHistory;
     if (h != null && h.title.isNotEmpty) {


### PR DESCRIPTION
# 漫画详情页离线体验优化方案

## 问题描述

进入漫画详情页时原为“全网络或全无”模式——网络请求失败则 data 为 null，直接显示 NetworkError，不展示任何信息。但本地已有的标题、封面、收藏状态、下载记录均未利用，导致离线时收藏/删除下载等操作按钮完全不可用。

## 解决方案

将 `ComicPageLogic.get()` 拆为两阶段：

- **阶段1 —— 本地优先**：立即从下载记录/阅读历史提取本地已保存的标题和封面，先渲染页面使操作按钮可用。
- **阶段2 —— 网络补全**：并行发起网络请求，成功后覆盖本地数据，失败则 toast 提示但不阻塞页面。

## 具体改动

- `ComicPageLogic` 新增 `networkMessage`、`loadLocalData` 字段。
- `get()` 拆为两阶段，`refresh_()` 清空新增状态。
- `BaseComicPage` 新增 `loadLocalData()`（默认返回 `null`，不影响已有子类）。
- `_ComicPageImpl.loadLocalData()` 按优先级查询：下载记录 → 阅读历史。
- `loadFavorite()` 改为 **OR 逻辑**，平台和本地任意一边收藏即为“已收藏”。
- `build()` 注入 `loadLocalData` 回调 + 网络失败 toast。

## 影响范围

仅影响走 `_ComicPageImpl` 路径的自定义 JS 源。6 个内置源子类（`PicacgComicPage` 等）`loadLocalData` 默认 `null`，行为不变。