### PR TITLE
修复 Android 设备中文文本异常渲染为宋体衬线字体问题

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -194,12 +194,14 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
         theme: ThemeData(
           colorScheme: lightColor,
           useMaterial3: true,
-          fontFamily: App.isWindows ? "font" : "",
+          fontFamily: App.isWindows ? "font" : null,
+          fontFamilyFallback: const ['sans-serif', 'Roboto', 'Noto Sans CJK SC'],
         ),
         darkTheme: ThemeData(
           colorScheme: darkColor,
           useMaterial3: true,
-          fontFamily: App.isWindows ? "font" : "",
+          fontFamily: App.isWindows ? "font" : null,
+          fontFamilyFallback: const ['sans-serif', 'Roboto', 'Noto Sans CJK SC'],
           brightness: Brightness.dark,
         ),
         themeMode: appdata.appSettings.darkMode == 2


### PR DESCRIPTION
fix #271

### 问题原因
原主题配置中，非 Windows 平台fontFamily赋值为空字符串""，触发底层 Skia 字体检索逻辑缺陷，字体回退匹配时错误选用宋体字体。
### 修复改动
1. 将Android端空字符串字体赋值修改为`null`，规避异常字体检索分支
2. 全局主题新增`sans-serif`无衬线字体兜底规则，统一中文展示样式
3. 保留Windows端自定义字体原有逻辑，不影响桌面端展示效果
