### PR TITLE
修复在有nhentai账号的情况下,验证cf时cookie 同步失败导致无限循环的bug

### DIFF
--- a/lib/network/cloudflare.dart
+++ b/lib/network/cloudflare.dart
@@ -120,6 +120,11 @@ void passCloudflare(CloudflareException e, void Function() onFinished) async {
       onTitleChange: (title, controller) async {
           var cookiesMap = await controller.getCookies(url);
           if (cookiesMap['cf_clearance'] != null) {
+              var isChallenge = await controller.evaluateJavascript(
+                  "typeof _cf_chl_opt !== 'undefined'");
+              if (isChallenge == 'true') {
+                  return;
+              }
               var ua = controller.userAgent;
               if (ua != null) {
                   appdata.implicitData[3] = ua;
@@ -140,6 +145,11 @@ void passCloudflare(CloudflareException e, void Function() onFinished) async {
         onTitleChange: (title, controller) async {
             var cookiesMap = await controller.getCookies(url) ?? {};
             if (cookiesMap['cf_clearance'] != null) {
+                var isChallenge = await controller.platform.evaluateJavascript(
+                    source: "typeof _cf_chl_opt !== 'undefined'");
+                if (isChallenge == true) {
+                    return;
+                }
                 var ua = await controller.getUA();
                 if (ua != null) {
                     appdata.implicitData[3] = ua;
@@ -154,10 +164,6 @@ void passCloudflare(CloudflareException e, void Function() onFinished) async {
             if (ua != null) {
                 appdata.implicitData[3] = ua;
                 appdata.writeImplicitData();
-            }
-            var cookiesMap = await controller.getCookies(url) ?? {};
-            if (cookiesMap['cf_clearance'] != null) {
-                saveCookies(cookiesMap);
             }
         },
       ),

--- a/lib/network/cloudflare.dart
+++ b/lib/network/cloudflare.dart
@@ -118,22 +118,17 @@ void passCloudflare(CloudflareException e, void Function() onFinished) async {
     var webview = DesktopWebview(
       initialUrl: url,
       onTitleChange: (title, controller) async {
-        var res = await controller.evaluateJavascript(
-            "document.head.innerHTML.includes('#challenge-success-text')");
-        if (res == 'false') {
-          var ua = controller.userAgent;
-          if (ua != null) {
-            appdata.implicitData[3] = ua;
-            appdata.writeImplicitData();
-          }
           var cookiesMap = await controller.getCookies(url);
-          if(cookiesMap['cf_clearance'] == null) {
-            return;
+          if (cookiesMap['cf_clearance'] != null) {
+              var ua = controller.userAgent;
+              if (ua != null) {
+                  appdata.implicitData[3] = ua;
+                  appdata.writeImplicitData();
+              }
+              saveCookies(cookiesMap);
+              controller.close();
+              onFinished();
           }
-          saveCookies(cookiesMap);
-          controller.close();
-          onFinished();
-        }
       },
     );
     webview.open();
@@ -143,31 +138,27 @@ void passCloudflare(CloudflareException e, void Function() onFinished) async {
         initialUrl: url,
         singlePage: true,
         onTitleChange: (title, controller) async {
-          var res = await controller.platform.evaluateJavascript(
-              source:
-                  "document.head.innerHTML.includes('#challenge-success-text')");
-          if (res == false) {
-            var ua = await controller.getUA();
-            if (ua != null) {
-              appdata.implicitData[3] = ua;
-              appdata.writeImplicitData();
-            }
             var cookiesMap = await controller.getCookies(url) ?? {};
-            if(cookiesMap['cf_clearance'] == null) {
-              return;
+            if (cookiesMap['cf_clearance'] != null) {
+                var ua = await controller.getUA();
+                if (ua != null) {
+                    appdata.implicitData[3] = ua;
+                    appdata.writeImplicitData();
+                }
+                saveCookies(cookiesMap);
+                App.globalBack();
             }
-            saveCookies(cookiesMap);
-            App.globalBack();
-          }
         },
         onStarted: (controller) async {
-          var ua = await controller.getUA();
-          if (ua != null) {
-            appdata.implicitData[3] = ua;
-            appdata.writeImplicitData();
-          }
-          var cookiesMap = await controller.getCookies(url) ?? {};
-          saveCookies(cookiesMap);
+            var ua = await controller.getUA();
+            if (ua != null) {
+                appdata.implicitData[3] = ua;
+                appdata.writeImplicitData();
+            }
+            var cookiesMap = await controller.getCookies(url) ?? {};
+            if (cookiesMap['cf_clearance'] != null) {
+                saveCookies(cookiesMap);
+            }
         },
       ),
     );


### PR DESCRIPTION
##问题
nhentai 触发 CF 验证时，用户点击「继续」进入 WebView 后，自动弹出.

##根因
passCloudflare() 中检测 CF 验证成功的机制有两层缺陷：
1. cookie 保存的触发条件错误：Desktop/Mobile 均以验证失败作为 cookie 保存的触发条件，验证成功时反而跳过。
2. 检测目标错误（根本原因）：检测对象为 DOM 元素 #challenge-success-text，该元素仅存在于 CF 验证通过的瞬时过渡页（<1 秒），而 onTitleChange 触发时页面已重定向到真实的 nhentai 页面，元素已消失，永远检测不到。
3. Mobile onStarted 在 WebView 刚创建时无条件保存 cookie，此时 CF 页面未加载，拿不到 cf_clearance。


##修复
将检测机制从脆弱的 DOM 元素改为 Cloudflare 标准 cookie cf_clearance，该 cookie 在 CF 验证通过后持久存在于 WebView 的 cookie store 中。
| 位置 | 改动概述 |
|------|----------|
| Desktop onTitleChange | 将检测方式从 JS 查询 DOM 元素 #challenge-success-text 改为直接检查 WebView cookie store 中是否存在 cf_clearance，同时删除 if 块内冗余的二次 cookie 检查 |
| Mobile onTitleChange | 同上 |
| Mobile onStarted | 将无条件 saveCookies 改为仅在 cf_clearance 存在时才保存，作为二次进入 WebView 时的快速同步路径 |

选择 cf_clearance 作为检测目标的理由：它是 Cloudflare 标准验证 cookie，验证通过后跨页面持久存在，不受页面重定向影响，且二次进入 WebView 时可直接命中。
