### PR TITLE
优化一下缓存机制

### DIFF
--- a/lib/foundation/cache_manager.dart
+++ b/lib/foundation/cache_manager.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
-import 'package:flutter/foundation.dart';
 import 'package:pica_comic/foundation/app.dart';
 import 'package:pica_comic/tools/io_extensions.dart';
 import 'package:sqlite3/sqlite3.dart';
@@ -24,6 +24,10 @@ class CacheManager {
 
   int get limitSize => _limitSize;
 
+  /// 修改 2：延迟初始化标记，避免在构造函数中执行重量级 IO
+  bool _sizeInitialized = false;
+  bool _needCheckAfterInit = false;
+
   CacheManager._create(){
     Directory(cachePath).createSync(recursive: true);
     _db = sqlite3.open('${App.dataPath}/cache.db');
@@ -44,15 +48,36 @@ class CacheManager {
     } catch (e) {
       // ignore
     }
-    compute((path) => Directory(path).size, cachePath)
-        .then((value) => _currentSize = value);
+    // 延迟初始化目录大小：避免在构造函数中执行重量级 IO（修改 2）
+    _initCurrentSize();
   }
 
   factory CacheManager() => instance ??= CacheManager._create();
 
+  /// 修改 2：异步初始化目录大小，使用安全的 _calcDirSize 避免 isolate OOM
+  Future<void> _initCurrentSize() async {
+    try {
+      _currentSize = await _calcDirSize(cachePath);
+    } catch (e) {
+      // 初始化失败回退为 0，避免 _sizeInitialized 为 true 但 _currentSize 为 null 时空指针
+      _currentSize = 0;
+    } finally {
+      _sizeInitialized = true;
+      if (_needCheckAfterInit) {
+        _needCheckAfterInit = false;
+        await checkCache();
+      }
+    }
+  }
+
   /// set cache size limit in MB
+  /// 修改 4：缩小限制时立即触发清理
   void setLimitSize(int size){
     _limitSize = size * 1024 * 1024;
+    // 如果当前缓存已超过新限制，触发清理
+    if (_sizeInitialized && _currentSize! > _limitSize) {
+      checkCache();
+    }
   }
 
   void setType(String key, String? type){
@@ -74,6 +99,7 @@ class CacheManager {
     return res.first[0];
   }
 
+  /// 修改 3：使用 _sizeInitialized 替代 _currentSize != null，新增 _needCheckAfterInit 分支
   Future<void> writeCache(String key, Uint8List data, [int duration = 7 * 24 * 60 * 60 * 1000]) async{
     this.dir++;
     this.dir %= 100;
@@ -90,11 +116,15 @@ class CacheManager {
     _db.execute('''
       INSERT OR REPLACE INTO cache (key, dir, name, expires) VALUES (?, ?, ?, ?)
     ''', [key, dir.toString(), name, expires]);
-    if(_currentSize != null) {
+
+    if (_sizeInitialized) {
       _currentSize = _currentSize! + data.length;
-    }
-    if(_currentSize != null && _currentSize! > _limitSize){
-      await checkCache();
+      if (_currentSize! > _limitSize) {
+        await checkCache();
+      }
+    } else {
+      // 目录大小尚未初始化完成，标记待初始化后补执行 checkCache
+      _needCheckAfterInit = true;
     }
   }
 
@@ -132,73 +162,96 @@ class CacheManager {
 
   bool _isChecking = false;
 
+  /// 修改 1：移除 compute，使用 _calcDirSize 避免 isolate OOM；加 try-finally 防止 _isChecking 锁死；
+  /// 添加 anyDeleted 防止空转死循环
   Future<void> checkCache() async{
     if(_isChecking){
       return;
     }
     _isChecking = true;
-    var res = _db.select('''
-      SELECT * FROM cache
-      WHERE expires < ?
-    ''', [DateTime.now().millisecondsSinceEpoch]);
-    for(var row in res){
-      var dir = row[1] as String;
-      var name = row[2] as String;
-      var file = File('$cachePath/$dir/$name');
-      if(await file.exists()){
-        await file.delete();
-      }
-    }
-    _db.execute('''
-      DELETE FROM cache
-      WHERE expires < ?
-    ''', [DateTime.now().millisecondsSinceEpoch]);
-
-    int count = 0;
-    var res2 = _db.select('''
-      SELECT COUNT(*) FROM cache
-    ''');
-    if(res2.isNotEmpty){
-      count = res2.first[0] as int;
-    }
-
-    compute((path) => Directory(path).size, cachePath)
-        .then((value) => _currentSize = value);
-
-    while((_currentSize != null && _currentSize! > _limitSize) ||  count > 2000){
+    try {
+      // 第一步：清理已过期的缓存条目
       var res = _db.select('''
         SELECT * FROM cache
-        ORDER BY expires ASC
-        limit 10
-      ''');
+        WHERE expires < ?
+      ''', [DateTime.now().millisecondsSinceEpoch]);
       for(var row in res){
-        var key = row[0] as String;
         var dir = row[1] as String;
         var name = row[2] as String;
         var file = File('$cachePath/$dir/$name');
         if(await file.exists()){
-          var size = await file.length();
           await file.delete();
-          _db.execute('''
-            DELETE FROM cache
-            WHERE key = ?
-          ''', [key]);
-          _currentSize = _currentSize! - size;
-          if(_currentSize! <= _limitSize){
-            break;
-          }
-        } else {
-          _db.execute('''
-            DELETE FROM cache
-            WHERE key = ?
-          ''', [key]);
         }
-        count--;
       }
+      _db.execute('''
+        DELETE FROM cache
+        WHERE expires < ?
+      ''', [DateTime.now().millisecondsSinceEpoch]);
+
+      // 第二步：获取当前条目数
+      int count = 0;
+      var res2 = _db.select('SELECT COUNT(*) FROM cache');
+      if(res2.isNotEmpty){
+        count = res2.first[0] as int;
+      }
+
+      // 第三步：在主 isolate 中直接计算目录大小（移除 compute，避免 isolate OOM）
+      _currentSize = await _calcDirSize(cachePath);
+
+      // 第四步：循环清理直到满足限制
+      while (_currentSize! > _limitSize || count > 2000) {
+        var res3 = _db.select('''
+          SELECT * FROM cache
+          ORDER BY expires ASC
+          LIMIT 10
+        ''');
+        bool anyDeleted = false;
+        for(var row in res3){
+          var key = row[0] as String;
+          var dir = row[1] as String;
+          var name = row[2] as String;
+          var file = File('$cachePath/$dir/$name');
+          if(await file.exists()){
+            var size = await file.length();
+            await file.delete();
+            _db.execute('DELETE FROM cache WHERE key = ?', [key]);
+            _currentSize = _currentSize! - size;
+            anyDeleted = true;
+            if(_currentSize! <= _limitSize && count - 1 <= 2000){
+              break;
+            }
+          } else {
+            _db.execute('DELETE FROM cache WHERE key = ?', [key]);
+            anyDeleted = true;
+          }
+          count--;
+        }
+        if (!anyDeleted) {
+          break; // 防止死循环：数据库中还有记录但文件都已不存在
+        }
+      }
+    } finally {
+      _isChecking = false;
     }
-    _isChecking = false;
   }
 
+  /// 修改 1：在主 isolate 中分批计算目录大小，避免 listSync(recursive: true) OOM
+  Future<int> _calcDirSize(String path) async {
+    int total = 0;
+    final dir = Directory(path);
+    if (!dir.existsSync()) return 0;
+    final List<FileSystemEntity> entries = dir.listSync();
+    for (final entity in entries) {
+      if (entity is File) {
+        total += await entity.length();
+      } else if (entity is Directory) {
+        total += await _calcDirSize(entity.path);
+      }
+    }
+    return total;
+  }
+
+  /// 修改 5：使用 _sizeInitialized 替代 _currentSize != null
   Future<void> delete(String key) async{
     var res = _db.select('''
       SELECT * FROM cache
@@ -220,7 +273,7 @@ class CacheManager {
       DELETE FROM cache
       WHERE key = ?
     ''', [key]);
-    if(_currentSize != null) {
+    if (_sizeInitialized) {
       _currentSize = _currentSize! - fileSize;
     }
   }
@@ -234,6 +287,7 @@ class CacheManager {
     _currentSize = 0;
   }
 
+  /// 修改 7：空 finally → deleteIgnoreError；修改 5：_currentSize != null → _sizeInitialized
   Future<void> deleteKeyword(String keyword) async{
     var res = _db.select('''
       SELECT * FROM cache
@@ -247,22 +301,20 @@ class CacheManager {
       var fileSize = 0;
       if(await file.exists()){
         fileSize = await file.length();
-        try {
-          await file.delete();
-        }
-        finally {}
+        await file.deleteIgnoreError();
       }
       _db.execute('''
         DELETE FROM cache
         WHERE key = ?
       ''', [key]);
-      if(_currentSize != null) {
+      if (_sizeInitialized) {
         _currentSize = _currentSize! - fileSize;
       }
     }
   }
 }
 
+/// 修改 6：新增 _writtenBytes 追踪，修改 close()/cancel()/reset() 同步 _currentSize
 class CachingFile{
   CachingFile._(this.key, this.dir, this.name, this.file);
 
@@ -276,10 +328,13 @@ class CachingFile{
 
   final List<int> _buffer = [];
 
+  int _writtenBytes = 0; // 跟踪已写入磁盘的字节数
+
   Future<void> writeBytes(List<int> data) async{
     _buffer.addAll(data);
     if(_buffer.length > 1024 * 1024){
       await file.writeAsBytes(_buffer, mode: FileMode.append);
+      _writtenBytes += _buffer.length;
       _buffer.clear();
     }
   }
@@ -287,18 +342,48 @@ class CachingFile{
   Future<void> close() async{
     if(_buffer.isNotEmpty){
       await file.writeAsBytes(_buffer, mode: FileMode.append);
+      _writtenBytes += _buffer.length;
+      _buffer.clear();
     }
     CacheManager()._db.execute('''
       INSERT OR REPLACE INTO cache (key, dir, name, expires) VALUES (?, ?, ?, ?)
     ''', [key, dir, name, DateTime.now().millisecondsSinceEpoch + 7 * 24 * 60 * 60 * 1000]);
-    await CacheManager().checkCache();
+
+    // 追踪写入的缓存大小
+    final cm = CacheManager();
+    if (cm._sizeInitialized) {
+      cm._currentSize = cm._currentSize! + _writtenBytes;
+      if (cm._currentSize! > cm._limitSize) {
+        await cm.checkCache();
+        return;
+      }
+    } else {
+      cm._needCheckAfterInit = true;
+    }
+
+    await cm.checkCache();
   }
 
   Future<void> cancel() async{
+    // 如果已写入部分数据且 _currentSize 已追踪，需要扣减
+    if (_writtenBytes > 0) {
+      final cm = CacheManager();
+      if (cm._sizeInitialized) {
+        cm._currentSize = cm._currentSize! - _writtenBytes;
+      }
+    }
     await file.deleteIgnoreError();
   }
 
   void reset() {
+    // 重置前扣减已追踪的大小
+    if (_writtenBytes > 0) {
+      final cm = CacheManager();
+      if (cm._sizeInitialized) {
+        cm._currentSize = cm._currentSize! - _writtenBytes;
+      }
+    }
+    _writtenBytes = 0;
     _buffer.clear();
     if(file.existsSync()) {
       file.deleteSync();

--- a/lib/foundation/cache_manager.dart
+++ b/lib/foundation/cache_manager.dart
@@ -262,35 +262,36 @@ class CacheManager {
   }
 
   Future<void> delete(String key) async{
-    var res = _db.select('''
-      SELECT * FROM cache
-      WHERE key = ?
-    ''', [key]);
-    if(res.isEmpty){
-      return;
-    }
-    var row = res.first;
-    var dir = row[1] as String;
-    var name = row[2] as String;
-    var file = File('$cachePath/$dir/$name');
-    var fileSize = 0;
-    try {
-      if(await file.exists()){
-        fileSize = await file.length();
-        await file.delete();
+      var res = _db.select('''
+        SELECT * FROM cache
+        WHERE key = ?
+      ''', [key]);
+      if(res.isEmpty){
+        return;
       }
-    } catch (_) {
-      // 权限不足或文件被外部删除时跳过
-      fileSize = 0;
+      var row = res.first;
+      var dir = row[1] as String;
+      var name = row[2] as String;
+      var file = File('$cachePath/$dir/$name');
+  
+      try {
+        if(await file.exists()){
+          var fileSize = await file.length();
+          await file.delete();
+          // 只有文件真正删除成功，才清理 DB 和扣减大小
+          _db.execute('DELETE FROM cache WHERE key = ?', [key]);
+          if (_currentSize != null) {
+            _currentSize = _currentSize! - fileSize;
+          }
+        } else {
+          // 文件已被外部删除，只清理 DB 记录
+          _db.execute('DELETE FROM cache WHERE key = ?', [key]);
+        }
+      } catch (_) {
+        // 文件操作失败，保留 DB 记录不删除
+        // 下次 delete() 或 checkCache() 会重试
+      }
     }
-    _db.execute('''
-      DELETE FROM cache
-      WHERE key = ?
-    ''', [key]);
-    if (_currentSize != null) {
-      _currentSize = _currentSize! - fileSize;
-    }
-  }
 
   Future<void> clear() async {
     try {

--- a/lib/foundation/cache_manager.dart
+++ b/lib/foundation/cache_manager.dart
@@ -150,12 +150,16 @@ class CacheManager {
     if(res.isEmpty){
       return null;
     }
-    var row = res.first;
-    var dir = row[1] as String;
-    var name = row[2] as String;
-    var file = File('$cachePath/$dir/$name');
-    if(await file.exists()){
-      return file.path;
+    try {
+      var row = res.first;
+      var dir = row[1] as String;
+      var name = row[2] as String;
+      var file = File('$cachePath/$dir/$name');
+      if(await file.exists()){
+        return file.path;
+      }
+    } catch (_) {
+      // 权限不足或文件系统异常时返回 null
     }
     return null;
   }
@@ -176,11 +180,15 @@ class CacheManager {
         WHERE expires < ?
       ''', [DateTime.now().millisecondsSinceEpoch]);
       for(var row in res){
-        var dir = row[1] as String;
-        var name = row[2] as String;
-        var file = File('$cachePath/$dir/$name');
-        if(await file.exists()){
-          await file.delete();
+        try {
+          var dir = row[1] as String;
+          var name = row[2] as String;
+          var file = File('$cachePath/$dir/$name');
+          if(await file.exists()){
+            await file.delete();
+          }
+        } catch (_) {
+          // 权限不足或文件被外部删除时跳过
         }
       }
       _db.execute('''
@@ -207,22 +215,29 @@ class CacheManager {
         ''');
         bool anyDeleted = false;
         for(var row in res3){
-          var key = row[0] as String;
-          var dir = row[1] as String;
-          var name = row[2] as String;
-          var file = File('$cachePath/$dir/$name');
-          if(await file.exists()){
-            var size = await file.length();
-            await file.delete();
-            _db.execute('DELETE FROM cache WHERE key = ?', [key]);
-            _currentSize = _currentSize! - size;
-            anyDeleted = true;
-            if(_currentSize! <= _limitSize && count - 1 <= 2000){
-              break;
+          int deletedCount = 0;
+          try {
+            var key = row[0] as String;
+            var dir = row[1] as String;
+            var name = row[2] as String;
+            var file = File('$cachePath/$dir/$name');
+            if(await file.exists()){
+              var size = await file.length();
+              await file.delete();
+              _db.execute('DELETE FROM cache WHERE key = ?', [key]);
+              _currentSize = _currentSize! - size;
+              anyDeleted = true;
+              deletedCount++;
+              if(_currentSize! <= _limitSize && count - deletedCount <= 2000){
+                break;
+              }
+            } else {
+              _db.execute('DELETE FROM cache WHERE key = ?', [key]);
+              anyDeleted = true;
+              deletedCount++;
             }
-          } else {
-            _db.execute('DELETE FROM cache WHERE key = ?', [key]);
-            anyDeleted = true;
+          } catch (_) {
+            // 权限不足或文件操作异常时跳过当前条目，继续处理下一个
           }
           count--;
         }
@@ -240,12 +255,16 @@ class CacheManager {
     int total = 0;
     final dir = Directory(path);
     if (!dir.existsSync()) return 0;
-    final List<FileSystemEntity> entries = dir.listSync();
+    final List<FileSystemEntity> entries = dir.listSync(followLinks: false);//防止目录包含软链接 / 符号链接（指向自身 / 上级目录），递归无限执行
     for (final entity in entries) {
-      if (entity is File) {
-        total += await entity.length();
-      } else if (entity is Directory) {
-        total += await _calcDirSize(entity.path);
+      try {
+        if (entity is File) {
+          total += await entity.length();
+        } else if (entity is Directory) {
+          total += await _calcDirSize(entity.path);
+        }
+      } catch (_) {
+        // 权限不足或文件被删除时跳过
       }
     }
     return total;
@@ -265,9 +284,14 @@ class CacheManager {
     var name = row[2] as String;
     var file = File('$cachePath/$dir/$name');
     var fileSize = 0;
-    if(await file.exists()){
-      fileSize = await file.length();
-      await file.delete();
+    try {
+      if(await file.exists()){
+        fileSize = await file.length();
+        await file.delete();
+      }
+    } catch (_) {
+      // 权限不足或文件被外部删除时跳过
+      fileSize = 0;
     }
     _db.execute('''
       DELETE FROM cache
@@ -279,7 +303,11 @@ class CacheManager {
   }
 
   Future<void> clear() async {
-    await Directory(cachePath).delete(recursive: true);
+    try {
+      await Directory(cachePath).delete(recursive: true);
+    } catch (_) {
+      // 权限不足时忽略
+    }
     Directory(cachePath).createSync(recursive: true);
     _db.execute('''
       DELETE FROM cache
@@ -299,10 +327,15 @@ class CacheManager {
       var name = row[2] as String;
       var file = File('$cachePath/$dir/$name');
       var fileSize = 0;
-      if(await file.exists()){
-        fileSize = await file.length();
-        await file.deleteIgnoreError();
+      try {
+        if(await file.exists()){
+          fileSize = await file.length();
+        }
+      } catch (_) {
+        // 权限不足或文件被外部删除时跳过
+        fileSize = 0;
       }
+      await file.deleteIgnoreError();
       _db.execute('''
         DELETE FROM cache
         WHERE key = ?

--- a/lib/foundation/cache_manager.dart
+++ b/lib/foundation/cache_manager.dart
@@ -24,10 +24,6 @@ class CacheManager {
 
   int get limitSize => _limitSize;
 
-  /// 修改 2：延迟初始化标记，避免在构造函数中执行重量级 IO
-  bool _sizeInitialized = false;
-  bool _needCheckAfterInit = false;
-
   CacheManager._create(){
     Directory(cachePath).createSync(recursive: true);
     _db = sqlite3.open('${App.dataPath}/cache.db');
@@ -48,25 +44,18 @@ class CacheManager {
     } catch (e) {
       // ignore
     }
-    // 延迟初始化目录大小：避免在构造函数中执行重量级 IO（修改 2）
     _initCurrentSize();
   }
 
   factory CacheManager() => instance ??= CacheManager._create();
 
-  /// 修改 2：异步初始化目录大小，使用安全的 _calcDirSize 避免 isolate OOM
+  /// 异步初始化目录大小，使用安全的 _calcDirSize 避免 isolate OOM
   Future<void> _initCurrentSize() async {
     try {
       _currentSize = await _calcDirSize(cachePath);
     } catch (e) {
-      // 初始化失败回退为 0，避免 _sizeInitialized 为 true 但 _currentSize 为 null 时空指针
+      // 初始化失败回退为 0
       _currentSize = 0;
-    } finally {
-      _sizeInitialized = true;
-      if (_needCheckAfterInit) {
-        _needCheckAfterInit = false;
-        await checkCache();
-      }
     }
   }
 
@@ -75,7 +64,7 @@ class CacheManager {
   void setLimitSize(int size){
     _limitSize = size * 1024 * 1024;
     // 如果当前缓存已超过新限制，触发清理
-    if (_sizeInitialized && _currentSize! > _limitSize) {
+    if (_currentSize != null && _currentSize! > _limitSize) {
       checkCache();
     }
   }
@@ -99,7 +88,6 @@ class CacheManager {
     return res.first[0];
   }
 
-  /// 修改 3：使用 _sizeInitialized 替代 _currentSize != null，新增 _needCheckAfterInit 分支
   Future<void> writeCache(String key, Uint8List data, [int duration = 7 * 24 * 60 * 60 * 1000]) async{
   this.dir++;
   this.dir %= 100;
@@ -126,13 +114,11 @@ class CacheManager {
     rethrow;
   }
 
-  if (_sizeInitialized) {
-    _currentSize = (_currentSize ?? 0) + data.length;
-    if ((_currentSize ?? 0) > _limitSize) {
+  if (_currentSize != null) {
+    _currentSize = _currentSize! + data.length;
+    if (_currentSize! > _limitSize) {
       await checkCache();
     }
-  } else {
-    _needCheckAfterInit = true;
   }
 }
 
@@ -275,7 +261,6 @@ class CacheManager {
     return total;
   }
 
-  /// 修改 5：使用 _sizeInitialized 替代 _currentSize != null
   Future<void> delete(String key) async{
     var res = _db.select('''
       SELECT * FROM cache
@@ -302,7 +287,7 @@ class CacheManager {
       DELETE FROM cache
       WHERE key = ?
     ''', [key]);
-    if (_sizeInitialized) {
+    if (_currentSize != null) {
       _currentSize = _currentSize! - fileSize;
     }
   }
@@ -320,7 +305,6 @@ class CacheManager {
     _currentSize = 0;
   }
 
-  /// 修改 7：空 finally → deleteIgnoreError；修改 5：_currentSize != null → _sizeInitialized
   Future<void> deleteKeyword(String keyword) async{
     var res = _db.select('''
       SELECT * FROM cache
@@ -345,7 +329,7 @@ class CacheManager {
         DELETE FROM cache
         WHERE key = ?
       ''', [key]);
-      if (_sizeInitialized) {
+      if (_currentSize != null) {
         _currentSize = _currentSize! - fileSize;
       }
     }
@@ -388,23 +372,19 @@ Future<void> close() async{
   ''', [key, dir, name, DateTime.now().millisecondsSinceEpoch + 7 * 24 * 60 * 60 * 1000]);
   // 追踪写入的缓存大小
   final cm = CacheManager();
-  if (cm._sizeInitialized) {
-    cm._currentSize = (cm._currentSize ?? 0) + _writtenBytes;
-    if ((cm._currentSize ?? 0) > cm._limitSize) {
+  if (cm._currentSize != null) {
+    cm._currentSize = cm._currentSize! + _writtenBytes;
+    if (cm._currentSize! > cm._limitSize) {
       await cm.checkCache();
     }
-  } else {
-    cm._needCheckAfterInit = true;
   }
-    //无条件触发改为按需触发
-  	//await cm.checkCache(); 
 }
 
   Future<void> cancel() async{
     // 如果已写入部分数据且 _currentSize 已追踪，需要扣减
     if (_writtenBytes > 0) {
       final cm = CacheManager();
-      if (cm._sizeInitialized) {
+      if (cm._currentSize != null) {
         cm._currentSize = cm._currentSize! - _writtenBytes;
       }
     }
@@ -415,7 +395,7 @@ Future<void> close() async{
     // 重置前扣减已追踪的大小
     if (_writtenBytes > 0) {
       final cm = CacheManager();
-      if (cm._sizeInitialized) {
+      if (cm._currentSize != null) {
         cm._currentSize = cm._currentSize! - _writtenBytes;
       }
     }

--- a/lib/foundation/cache_manager.dart
+++ b/lib/foundation/cache_manager.dart
@@ -62,12 +62,14 @@ class CacheManager {
   /// set cache size limit in MB
   /// 修改 4：缩小限制时立即触发清理
   void setLimitSize(int size){
-    _limitSize = size * 1024 * 1024;
-    // 如果当前缓存已超过新限制，触发清理
-    if (_currentSize != null && _currentSize! > _limitSize) {
-      checkCache();
+      _limitSize = size * 1024 * 1024;
+      if (_currentSize != null && _currentSize! > _limitSize) {
+        checkCache().catchError((_) {
+          // ignore: checkCache 失败不影响 setLimitSize，下次写入或手动触发会重试
+        });
+      }
     }
-  }
+
 
   void setType(String key, String? type){
     _db.execute('''

--- a/lib/foundation/cache_manager.dart
+++ b/lib/foundation/cache_manager.dart
@@ -215,7 +215,6 @@ class CacheManager {
         ''');
         bool anyDeleted = false;
         for(var row in res3){
-          int deletedCount = 0;
           try {
             var key = row[0] as String;
             var dir = row[1] as String;
@@ -227,17 +226,15 @@ class CacheManager {
               _db.execute('DELETE FROM cache WHERE key = ?', [key]);
               _currentSize = _currentSize! - size;
               anyDeleted = true;
-              deletedCount++;
-              if(_currentSize! <= _limitSize && count - deletedCount <= 2000){
+              if(_currentSize! <= _limitSize && count - 1 <= 2000){
                 break;
               }
             } else {
               _db.execute('DELETE FROM cache WHERE key = ?', [key]);
               anyDeleted = true;
-              deletedCount++;
             }
-          } catch (_) {
-            // 权限不足或文件操作异常时跳过当前条目，继续处理下一个
+          } catch (_) { 
+            //// 权限不足或文件操作异常时跳过当前条目，继续处理下一个
           }
           count--;
         }

--- a/lib/foundation/cache_manager.dart
+++ b/lib/foundation/cache_manager.dart
@@ -101,32 +101,40 @@ class CacheManager {
 
   /// 修改 3：使用 _sizeInitialized 替代 _currentSize != null，新增 _needCheckAfterInit 分支
   Future<void> writeCache(String key, Uint8List data, [int duration = 7 * 24 * 60 * 60 * 1000]) async{
-    this.dir++;
-    this.dir %= 100;
-    var dir = this.dir;
-    var name = md5.convert(Uint8List.fromList(key.codeUnits)).toString();
-    var file = File('$cachePath/$dir/$name');
-    while(await file.exists()){
-      name = md5.convert(Uint8List.fromList(name.codeUnits)).toString();
-      file = File('$cachePath/$dir/$name');
-    }
+  this.dir++;
+  this.dir %= 100;
+  var dir = this.dir;
+  var name = md5.convert(Uint8List.fromList(key.codeUnits)).toString();
+  var file = File('$cachePath/$dir/$name');
+  while(await file.exists()){
+    name = md5.convert(Uint8List.fromList(name.codeUnits)).toString();
+    file = File('$cachePath/$dir/$name');
+  }
+
+  // 先写入 DB 记录，再写文件：确保 DB 是文件的权威来源
+  var expires = DateTime.now().millisecondsSinceEpoch + duration;
+  _db.execute('''
+    INSERT OR REPLACE INTO cache (key, dir, name, expires) VALUES (?, ?, ?, ?)
+  ''', [key, dir.toString(), name, expires]);
+
+  try {
     await file.create(recursive: true);
     await file.writeAsBytes(data);
-    var expires = DateTime.now().millisecondsSinceEpoch + duration;
-    _db.execute('''
-      INSERT OR REPLACE INTO cache (key, dir, name, expires) VALUES (?, ?, ?, ?)
-    ''', [key, dir.toString(), name, expires]);
-
-    if (_sizeInitialized) {
-      _currentSize = _currentSize! + data.length;
-      if (_currentSize! > _limitSize) {
-        await checkCache();
-      }
-    } else {
-      // 目录大小尚未初始化完成，标记待初始化后补执行 checkCache
-      _needCheckAfterInit = true;
-    }
+  } catch (e) {
+    // 文件写入失败，回滚 DB 记录，防止 DB 中存在无对应文件的记录
+    _db.execute('DELETE FROM cache WHERE key = ?', [key]);
+    rethrow;
   }
+
+  if (_sizeInitialized) {
+    _currentSize = (_currentSize ?? 0) + data.length;
+    if ((_currentSize ?? 0) > _limitSize) {
+      await checkCache();
+    }
+  } else {
+    _needCheckAfterInit = true;
+  }
+}
 
   Future<CachingFile> openWrite(String key) async{
     this.dir++;

--- a/lib/foundation/cache_manager.dart
+++ b/lib/foundation/cache_manager.dart
@@ -377,30 +377,28 @@ class CachingFile{
     }
   }
 
-  Future<void> close() async{
-    if(_buffer.isNotEmpty){
-      await file.writeAsBytes(_buffer, mode: FileMode.append);
-      _writtenBytes += _buffer.length;
-      _buffer.clear();
-    }
-    CacheManager()._db.execute('''
-      INSERT OR REPLACE INTO cache (key, dir, name, expires) VALUES (?, ?, ?, ?)
-    ''', [key, dir, name, DateTime.now().millisecondsSinceEpoch + 7 * 24 * 60 * 60 * 1000]);
-
-    // 追踪写入的缓存大小
-    final cm = CacheManager();
-    if (cm._sizeInitialized) {
-      cm._currentSize = cm._currentSize! + _writtenBytes;
-      if (cm._currentSize! > cm._limitSize) {
-        await cm.checkCache();
-        return;
-      }
-    } else {
-      cm._needCheckAfterInit = true;
-    }
-
-    await cm.checkCache();
+Future<void> close() async{
+  if(_buffer.isNotEmpty){
+    await file.writeAsBytes(_buffer, mode: FileMode.append);
+    _writtenBytes += _buffer.length;
+    _buffer.clear();
   }
+  CacheManager()._db.execute('''
+    INSERT OR REPLACE INTO cache (key, dir, name, expires) VALUES (?, ?, ?, ?)
+  ''', [key, dir, name, DateTime.now().millisecondsSinceEpoch + 7 * 24 * 60 * 60 * 1000]);
+  // 追踪写入的缓存大小
+  final cm = CacheManager();
+  if (cm._sizeInitialized) {
+    cm._currentSize = (cm._currentSize ?? 0) + _writtenBytes;
+    if ((cm._currentSize ?? 0) > cm._limitSize) {
+      await cm.checkCache();
+    }
+  } else {
+    cm._needCheckAfterInit = true;
+  }
+    //无条件触发改为按需触发
+  	//await cm.checkCache(); 
+}
 
   Future<void> cancel() async{
     // 如果已写入部分数据且 _currentSize 已追踪，需要扣减

--- a/lib/foundation/cache_manager.dart
+++ b/lib/foundation/cache_manager.dart
@@ -1,7 +1,8 @@
 import 'dart:io';
-import 'dart:typed_data';
+import 'dart:isolate';
 
 import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
 import 'package:pica_comic/foundation/app.dart';
 import 'package:pica_comic/tools/io_extensions.dart';
 import 'package:sqlite3/sqlite3.dart';
@@ -20,13 +21,78 @@ class CacheManager {
 
   int dir = 0;
 
+  /// 数据库文件路径, 用于初始化扫描
+  late String _dbPath;
+
+  /// 初始化扫描任务, 完成后 _currentSize 为真实大小
+  Future<void>? _initialScanTask;
+
   int _limitSize = 2 * 1024 * 1024 * 1024;
 
   int get limitSize => _limitSize;
 
+  /// 扫描缓存目录, 统计有效缓存大小并找出孤立文件
+  static Future<int> _scanDir(String dbPath, String cacheDir) async {
+    final res = await Isolate.run(() async {
+      int totalSize = 0;
+      final unmanagedFiles = <String>[];
+      var db = sqlite3.open(dbPath);
+      try {
+        var d = Directory(cacheDir);
+        if (await d.exists()) {
+          await for (var entity in d.list(recursive: true)) {
+            if (entity is File) {
+              var segs = entity.uri.pathSegments;
+              var name = segs.last;
+              var dirName = segs.length >= 2 ? segs[segs.length - 2] : "*";
+              var rows = db.select(
+                'SELECT * FROM cache WHERE dir = ? AND name = ?',
+                [dirName, name],
+              );
+              if (rows.isEmpty) {
+                unmanagedFiles.add(entity.path);
+              } else {
+                totalSize += await entity.length();
+              }
+            }
+          }
+        }
+      } finally {
+        db.dispose();
+      }
+      return {'totalSize': totalSize, 'unmanagedFiles': unmanagedFiles};
+    });
+    // 主 isolate 中删除孤立文件并清理数据库记录
+    for (var filePath in res['unmanagedFiles'] as List<String>) {
+      var file = File(filePath);
+      if (await file.exists()) {
+        await file.delete();
+      }
+      var segs = file.uri.pathSegments;
+      var name = segs.last;
+      var dirName = segs.length >= 2 ? segs[segs.length - 2] : "*";
+      CacheManager()._db.execute(
+        'DELETE FROM cache WHERE dir = ? AND name = ?',
+        [dirName, name],
+      );
+    }
+    return res['totalSize'] as int;
+  }
+
+  /// 初始化时扫描缓存目录, 校准大小并清理孤立文件
+  Future<void> _runInitialScan() async {
+    try {
+      _currentSize = await _scanDir(_dbPath, cachePath);
+      await checkCache();
+    } catch (_) {
+      _currentSize = 0;
+    }
+  }
+
   CacheManager._create(){
     Directory(cachePath).createSync(recursive: true);
-    _db = sqlite3.open('${App.dataPath}/cache.db');
+    _dbPath = '${App.dataPath}/cache.db';
+    _db = sqlite3.open(_dbPath);
     _db.execute('''
       CREATE TABLE IF NOT EXISTS cache (
         key TEXT PRIMARY KEY NOT NULL,
@@ -44,32 +110,16 @@ class CacheManager {
     } catch (e) {
       // ignore
     }
-    _initCurrentSize();
+    // 初始化时在后台 isolate 中扫描缓存目录, 校准大小并清理孤立文件
+    _initialScanTask = _runInitialScan();
   }
 
   factory CacheManager() => instance ??= CacheManager._create();
 
-  /// 异步初始化目录大小，使用安全的 _calcDirSize 避免 isolate OOM
-  Future<void> _initCurrentSize() async {
-    try {
-      _currentSize = await _calcDirSize(cachePath);
-    } catch (e) {
-      // 初始化失败回退为 0
-      _currentSize = 0;
-    }
-  }
-
   /// set cache size limit in MB
-  /// 修改 4：缩小限制时立即触发清理
   void setLimitSize(int size){
-      _limitSize = size * 1024 * 1024;
-      if (_currentSize != null && _currentSize! > _limitSize) {
-        checkCache().catchError((_) {
-          // ignore: checkCache 失败不影响 setLimitSize，下次写入或手动触发会重试
-        });
-      }
-    }
-
+    _limitSize = size * 1024 * 1024;
+  }
 
   void setType(String key, String? type){
     _db.execute('''
@@ -91,38 +141,28 @@ class CacheManager {
   }
 
   Future<void> writeCache(String key, Uint8List data, [int duration = 7 * 24 * 60 * 60 * 1000]) async{
-  this.dir++;
-  this.dir %= 100;
-  var dir = this.dir;
-  var name = md5.convert(Uint8List.fromList(key.codeUnits)).toString();
-  var file = File('$cachePath/$dir/$name');
-  while(await file.exists()){
-    name = md5.convert(Uint8List.fromList(name.codeUnits)).toString();
-    file = File('$cachePath/$dir/$name');
-  }
-
-  // 先写入 DB 记录，再写文件：确保 DB 是文件的权威来源
-  var expires = DateTime.now().millisecondsSinceEpoch + duration;
-  _db.execute('''
-    INSERT OR REPLACE INTO cache (key, dir, name, expires) VALUES (?, ?, ?, ?)
-  ''', [key, dir.toString(), name, expires]);
-
-  try {
+    this.dir++;
+    this.dir %= 100;
+    var dir = this.dir;
+    var name = md5.convert(Uint8List.fromList(key.codeUnits)).toString();
+    var file = File('$cachePath/$dir/$name');
+    while(await file.exists()){
+      name = md5.convert(Uint8List.fromList(name.codeUnits)).toString();
+      file = File('$cachePath/$dir/$name');
+    }
     await file.create(recursive: true);
     await file.writeAsBytes(data);
-  } catch (e) {
-    // 文件写入失败，回滚 DB 记录，防止 DB 中存在无对应文件的记录
-    _db.execute('DELETE FROM cache WHERE key = ?', [key]);
-    rethrow;
-  }
-
-  if (_currentSize != null) {
-    _currentSize = _currentSize! + data.length;
-    if (_currentSize! > _limitSize) {
+    var expires = DateTime.now().millisecondsSinceEpoch + duration;
+    _db.execute('''
+      INSERT OR REPLACE INTO cache (key, dir, name, expires) VALUES (?, ?, ?, ?)
+    ''', [key, dir.toString(), name, expires]);
+    if(_currentSize != null) {
+      _currentSize = _currentSize! + data.length;
+    }
+    if(_currentSize != null && _currentSize! > _limitSize){
       await checkCache();
     }
   }
-}
 
   Future<CachingFile> openWrite(String key) async{
     this.dir++;
@@ -146,45 +186,70 @@ class CacheManager {
     if(res.isEmpty){
       return null;
     }
-    try {
-      var row = res.first;
-      var dir = row[1] as String;
-      var name = row[2] as String;
-      var file = File('$cachePath/$dir/$name');
+    var row = res.first;
+    var dir = row[1] as String;
+    var name = row[2] as String;
+    var expires = row[3] as int;
+    var file = File('$cachePath/$dir/$name');
+    var now = DateTime.now().millisecondsSinceEpoch;
+
+    // 过期缓存直接删除并返回 null
+    if(expires < now){
+      _db.execute('''
+        DELETE FROM cache
+        WHERE key = ?
+      ''', [key]);
       if(await file.exists()){
-        return file.path;
+        var size = await file.length();
+        if(_currentSize != null) {
+          _currentSize = _currentSize! - size;
+        }
+        await file.delete();
       }
-    } catch (_) {
-      // 权限不足或文件系统异常时返回 null
+      return null;
     }
+
+    // 命中缓存, LRU 续期 7 天
+    if(await file.exists()){
+      var newExpires = now + 7 * 24 * 60 * 60 * 1000;
+      _db.execute('''
+        UPDATE cache
+        SET expires = ?
+        WHERE key = ?
+      ''', [newExpires, key]);
+      return file.path;
+    }
+
+    // 文件丢失, 清理数据库脏记录
+    _db.execute('''
+      DELETE FROM cache
+      WHERE key = ?
+    ''', [key]);
     return null;
   }
 
   bool _isChecking = false;
 
-  /// 修改 1：移除 compute，使用 _calcDirSize 避免 isolate OOM；加 try-finally 防止 _isChecking 锁死；
-  /// 添加 anyDeleted 防止空转死循环
   Future<void> checkCache() async{
     if(_isChecking){
       return;
     }
     _isChecking = true;
     try {
-      // 第一步：清理已过期的缓存条目
       var res = _db.select('''
         SELECT * FROM cache
         WHERE expires < ?
       ''', [DateTime.now().millisecondsSinceEpoch]);
       for(var row in res){
-        try {
-          var dir = row[1] as String;
-          var name = row[2] as String;
-          var file = File('$cachePath/$dir/$name');
-          if(await file.exists()){
-            await file.delete();
+        var dir = row[1] as String;
+        var name = row[2] as String;
+        var file = File('$cachePath/$dir/$name');
+        if(await file.exists()){
+          var size = await file.length();
+          await file.delete();
+          if(_currentSize != null){
+            _currentSize = _currentSize! - size;
           }
-        } catch (_) {
-          // 权限不足或文件被外部删除时跳过
         }
       }
       _db.execute('''
@@ -192,52 +257,53 @@ class CacheManager {
         WHERE expires < ?
       ''', [DateTime.now().millisecondsSinceEpoch]);
 
-      // 第二步：获取当前条目数
-      // int count = 0;
-      // var res2 = _db.select('SELECT COUNT(*) FROM cache');
-      // if(res2.isNotEmpty){
-      //   count = res2.first[0] as int;
-      // }
+      int count = 0;
+      var res2 = _db.select('''
+        SELECT COUNT(*) FROM cache
+      ''');
+      if(res2.isNotEmpty){
+        count = res2.first[0] as int;
+      }
 
-      // 第三步：在主 isolate 中直接计算目录大小（移除 compute，避免 isolate OOM）
-      _currentSize = await _calcDirSize(cachePath);
+      compute((path) => Directory(path).size, cachePath)
+          .then((value) => _currentSize = value);
 
-      // 第四步：循环清理直到满足限制
-      // while (_currentSize! > _limitSize || count > 2000) {
-      while (_currentSize! > _limitSize) {
-        var res3 = _db.select('''
+      while((_currentSize != null && _currentSize! > _limitSize) ||  count > 2000){
+        var res = _db.select('''
           SELECT * FROM cache
           ORDER BY expires ASC
-          LIMIT 10
+          limit 10
         ''');
-        bool anyDeleted = false;
-        for(var row in res3){
-          try {
-            var key = row[0] as String;
-            var dir = row[1] as String;
-            var name = row[2] as String;
-            var file = File('$cachePath/$dir/$name');
-            if(await file.exists()){
-              var size = await file.length();
-              await file.delete();
-              _db.execute('DELETE FROM cache WHERE key = ?', [key]);
-              _currentSize = _currentSize! - size;
-              anyDeleted = true;
-              // if(_currentSize! <= _limitSize && count - 1 <= 2000){
-              if(_currentSize! <= _limitSize){
-                break;
-              }
-            } else {
-              _db.execute('DELETE FROM cache WHERE key = ?', [key]);
-              anyDeleted = true;
-            }
-          } catch (_) { 
-            //// 权限不足或文件操作异常时跳过当前条目，继续处理下一个
-          }
-          // count--;
+        // 数据库中无记录但磁盘仍超限, 直接清空缓存目录
+        if(res.isEmpty){
+          await Directory(cachePath).delete(recursive: true);
+          Directory(cachePath).createSync(recursive: true);
+          _currentSize = 0;
+          break;
         }
-        if (!anyDeleted) {
-          break; // 防止死循环：数据库中还有记录但文件都已不存在
+        for(var row in res){
+          var key = row[0] as String;
+          var dir = row[1] as String;
+          var name = row[2] as String;
+          var file = File('$cachePath/$dir/$name');
+          if(await file.exists()){
+            var size = await file.length();
+            await file.delete();
+            _db.execute('''
+              DELETE FROM cache
+              WHERE key = ?
+            ''', [key]);
+            _currentSize = _currentSize! - size;
+            if(_currentSize! <= _limitSize){
+              break;
+            }
+          } else {
+            _db.execute('''
+              DELETE FROM cache
+              WHERE key = ?
+            ''', [key]);
+          }
+          count--;
         }
       }
     } finally {
@@ -245,64 +311,34 @@ class CacheManager {
     }
   }
 
-  /// 修改 1：在主 isolate 中分批计算目录大小，避免 listSync(recursive: true) OOM
-  Future<int> _calcDirSize(String path) async {
-    int total = 0;
-    final dir = Directory(path);
-    if (!dir.existsSync()) return 0;
-    final List<FileSystemEntity> entries = dir.listSync(followLinks: false);//防止目录包含软链接 / 符号链接（指向自身 / 上级目录），递归无限执行
-    for (final entity in entries) {
-      try {
-        if (entity is File) {
-          total += await entity.length();
-        } else if (entity is Directory) {
-          total += await _calcDirSize(entity.path);
-        }
-      } catch (_) {
-        // 权限不足或文件被删除时跳过
-      }
+  Future<void> delete(String key) async{
+    var res = _db.select('''
+      SELECT * FROM cache
+      WHERE key = ?
+    ''', [key]);
+    if(res.isEmpty){
+      return;
     }
-    return total;
+    var row = res.first;
+    var dir = row[1] as String;
+    var name = row[2] as String;
+    var file = File('$cachePath/$dir/$name');
+    var fileSize = 0;
+    if(await file.exists()){
+      fileSize = await file.length();
+      await file.delete();
+    }
+    _db.execute('''
+      DELETE FROM cache
+      WHERE key = ?
+    ''', [key]);
+    if(_currentSize != null) {
+      _currentSize = _currentSize! - fileSize;
+    }
   }
 
-  Future<void> delete(String key) async{
-      var res = _db.select('''
-        SELECT * FROM cache
-        WHERE key = ?
-      ''', [key]);
-      if(res.isEmpty){
-        return;
-      }
-      var row = res.first;
-      var dir = row[1] as String;
-      var name = row[2] as String;
-      var file = File('$cachePath/$dir/$name');
-  
-      try {
-        if(await file.exists()){
-          var fileSize = await file.length();
-          await file.delete();
-          // 只有文件真正删除成功，才清理 DB 和扣减大小
-          _db.execute('DELETE FROM cache WHERE key = ?', [key]);
-          if (_currentSize != null) {
-            _currentSize = _currentSize! - fileSize;
-          }
-        } else {
-          // 文件已被外部删除，只清理 DB 记录
-          _db.execute('DELETE FROM cache WHERE key = ?', [key]);
-        }
-      } catch (_) {
-        // 文件操作失败，保留 DB 记录不删除
-        // 下次 delete() 或 checkCache() 会重试
-      }
-    }
-
   Future<void> clear() async {
-    try {
-      await Directory(cachePath).delete(recursive: true);
-    } catch (_) {
-      // 权限不足时忽略
-    }
+    await Directory(cachePath).delete(recursive: true);
     Directory(cachePath).createSync(recursive: true);
     _db.execute('''
       DELETE FROM cache
@@ -321,27 +357,24 @@ class CacheManager {
       var name = row[2] as String;
       var file = File('$cachePath/$dir/$name');
       var fileSize = 0;
-      try {
-        if(await file.exists()){
-          fileSize = await file.length();
+      if(await file.exists()){
+        fileSize = await file.length();
+        try {
+          await file.delete();
         }
-      } catch (_) {
-        // 权限不足或文件被外部删除时跳过
-        fileSize = 0;
+        finally {}
       }
-      await file.deleteIgnoreError();
       _db.execute('''
         DELETE FROM cache
         WHERE key = ?
       ''', [key]);
-      if (_currentSize != null) {
+      if(_currentSize != null) {
         _currentSize = _currentSize! - fileSize;
       }
     }
   }
 }
 
-/// 修改 6：新增 _writtenBytes 追踪，修改 close()/cancel()/reset() 同步 _currentSize
 class CachingFile{
   CachingFile._(this.key, this.dir, this.name, this.file);
 
@@ -355,56 +388,29 @@ class CachingFile{
 
   final List<int> _buffer = [];
 
-  int _writtenBytes = 0; // 跟踪已写入磁盘的字节数
-
   Future<void> writeBytes(List<int> data) async{
     _buffer.addAll(data);
     if(_buffer.length > 1024 * 1024){
       await file.writeAsBytes(_buffer, mode: FileMode.append);
-      _writtenBytes += _buffer.length;
       _buffer.clear();
     }
   }
 
-Future<void> close() async{
-  if(_buffer.isNotEmpty){
-    await file.writeAsBytes(_buffer, mode: FileMode.append);
-    _writtenBytes += _buffer.length;
-    _buffer.clear();
-  }
-  CacheManager()._db.execute('''
-    INSERT OR REPLACE INTO cache (key, dir, name, expires) VALUES (?, ?, ?, ?)
-  ''', [key, dir, name, DateTime.now().millisecondsSinceEpoch + 7 * 24 * 60 * 60 * 1000]);
-  // 追踪写入的缓存大小
-  final cm = CacheManager();
-  if (cm._currentSize != null) {
-    cm._currentSize = cm._currentSize! + _writtenBytes;
-    if (cm._currentSize! > cm._limitSize) {
-      await cm.checkCache();
+  Future<void> close() async{
+    if(_buffer.isNotEmpty){
+      await file.writeAsBytes(_buffer, mode: FileMode.append);
     }
+    CacheManager()._db.execute('''
+      INSERT OR REPLACE INTO cache (key, dir, name, expires) VALUES (?, ?, ?, ?)
+    ''', [key, dir, name, DateTime.now().millisecondsSinceEpoch + 7 * 24 * 60 * 60 * 1000]);
+    await CacheManager().checkCache();
   }
-}
 
   Future<void> cancel() async{
-    // 如果已写入部分数据且 _currentSize 已追踪，需要扣减
-    if (_writtenBytes > 0) {
-      final cm = CacheManager();
-      if (cm._currentSize != null) {
-        cm._currentSize = cm._currentSize! - _writtenBytes;
-      }
-    }
     await file.deleteIgnoreError();
   }
 
   void reset() {
-    // 重置前扣减已追踪的大小
-    if (_writtenBytes > 0) {
-      final cm = CacheManager();
-      if (cm._currentSize != null) {
-        cm._currentSize = cm._currentSize! - _writtenBytes;
-      }
-    }
-    _writtenBytes = 0;
     _buffer.clear();
     if(file.existsSync()) {
       file.deleteSync();

--- a/lib/foundation/cache_manager.dart
+++ b/lib/foundation/cache_manager.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:isolate';
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
@@ -31,37 +30,45 @@ class CacheManager {
 
   int get limitSize => _limitSize;
 
-  /// 扫描缓存目录, 统计有效缓存大小并找出孤立文件
-  static Future<int> _scanDir(String dbPath, String cacheDir) async {
-    final res = await Isolate.run(() async {
-      int totalSize = 0;
-      final unmanagedFiles = <String>[];
-      var db = sqlite3.open(dbPath);
-      try {
-        var d = Directory(cacheDir);
-        if (await d.exists()) {
-          await for (var entity in d.list(recursive: true)) {
-            if (entity is File) {
-              var segs = entity.uri.pathSegments;
-              var name = segs.last;
-              var dirName = segs.length >= 2 ? segs[segs.length - 2] : "*";
-              var rows = db.select(
-                'SELECT * FROM cache WHERE dir = ? AND name = ?',
-                [dirName, name],
-              );
-              if (rows.isEmpty) {
-                unmanagedFiles.add(entity.path);
-              } else {
-                totalSize += await entity.length();
-              }
+  /// compute 回调: 在后台 isolate 中扫描缓存目录
+  ///
+  /// 必须是无捕获的静态方法, 以便在 web 平台由 compute 降级为同线程执行。
+  static Future<Map<String, Object?>> _scanDirCallback(
+      List<String> args) async {
+    final dbPath = args[0];
+    final cacheDir = args[1];
+    int totalSize = 0;
+    final unmanagedFiles = <String>[];
+    var db = sqlite3.open(dbPath);
+    try {
+      var d = Directory(cacheDir);
+      if (await d.exists()) {
+        await for (var entity in d.list(recursive: true)) {
+          if (entity is File) {
+            var segs = entity.uri.pathSegments;
+            var name = segs.last;
+            var dirName = segs.length >= 2 ? segs[segs.length - 2] : "*";
+            var rows = db.select(
+              'SELECT * FROM cache WHERE dir = ? AND name = ?',
+              [dirName, name],
+            );
+            if (rows.isEmpty) {
+              unmanagedFiles.add(entity.path);
+            } else {
+              totalSize += await entity.length();
             }
           }
         }
-      } finally {
-        db.dispose();
       }
-      return {'totalSize': totalSize, 'unmanagedFiles': unmanagedFiles};
-    });
+    } finally {
+      db.dispose();
+    }
+    return {'totalSize': totalSize, 'unmanagedFiles': unmanagedFiles};
+  }
+
+  /// 扫描缓存目录, 统计有效缓存大小并找出孤立文件
+  static Future<int> _scanDir(String dbPath, String cacheDir) async {
+    final res = await compute(_scanDirCallback, [dbPath, cacheDir]);
     // 主 isolate 中删除孤立文件并清理数据库记录
     for (var filePath in res['unmanagedFiles'] as List<String>) {
       var file = File(filePath);
@@ -118,6 +125,10 @@ class CacheManager {
 
   /// set cache size limit in MB
   void setLimitSize(int size){
+    if(size <= 0){
+      // 非法值忽略, 防止 _limitSize <= 0 导致缓存被全部清空
+      return;
+    }
     _limitSize = size * 1024 * 1024;
   }
 
@@ -141,6 +152,18 @@ class CacheManager {
   }
 
   Future<void> writeCache(String key, Uint8List data, [int duration = 7 * 24 * 60 * 60 * 1000]) async{
+    // 删除该 key 的旧缓存文件, 防止 INSERT OR REPLACE 后旧文件永久残留
+    var oldPath = await findCache(key);
+    if(oldPath != null){
+      var oldFile = File(oldPath);
+      if(await oldFile.exists()){
+        var oldSize = await oldFile.length();
+        await oldFile.delete();
+        if(_currentSize != null){
+          _currentSize = _currentSize! - oldSize;
+        }
+      }
+    }
     this.dir++;
     this.dir %= 100;
     var dir = this.dir;
@@ -152,7 +175,9 @@ class CacheManager {
     }
     await file.create(recursive: true);
     await file.writeAsBytes(data);
-    var expires = DateTime.now().millisecondsSinceEpoch + duration;
+    // duration <= 0 表示永久缓存 (expires = 0), 与 findCache/checkCache 的 expires > 0 判断配合
+    var expires =
+        duration <= 0 ? 0 : DateTime.now().millisecondsSinceEpoch + duration;
     _db.execute('''
       INSERT OR REPLACE INTO cache (key, dir, name, expires) VALUES (?, ?, ?, ?)
     ''', [key, dir.toString(), name, expires]);
@@ -165,6 +190,8 @@ class CacheManager {
   }
 
   Future<CachingFile> openWrite(String key) async{
+    // 删除该 key 的旧缓存文件, 防止同一 key 多次流式写入时旧文件永久残留
+    await delete(key);
     this.dir++;
     this.dir %= 100;
     var dir = this.dir;
@@ -193,8 +220,8 @@ class CacheManager {
     var file = File('$cachePath/$dir/$name');
     var now = DateTime.now().millisecondsSinceEpoch;
 
-    // 过期缓存直接删除并返回 null
-    if(expires < now){
+    // 过期缓存直接删除并返回 null (expires <= 0 视为永久缓存, 不过期)
+    if(expires > 0 && expires < now){
       _db.execute('''
         DELETE FROM cache
         WHERE key = ?
@@ -209,14 +236,15 @@ class CacheManager {
       return null;
     }
 
-    // 命中缓存, LRU 续期 7 天
+    // 命中缓存, LRU 续期 7 天 (永久缓存 expires <= 0 不续期)
     if(await file.exists()){
-      var newExpires = now + 7 * 24 * 60 * 60 * 1000;
-      _db.execute('''
-        UPDATE cache
-        SET expires = ?
-        WHERE key = ?
-      ''', [newExpires, key]);
+      if(expires > 0){
+        _db.execute('''
+          UPDATE cache
+          SET expires = ?
+          WHERE key = ?
+        ''', [now + 7 * 24 * 60 * 60 * 1000, key]);
+      }
       return file.path;
     }
 
@@ -238,7 +266,7 @@ class CacheManager {
     try {
       var res = _db.select('''
         SELECT * FROM cache
-        WHERE expires < ?
+        WHERE expires > 0 AND expires < ?
       ''', [DateTime.now().millisecondsSinceEpoch]);
       for(var row in res){
         var dir = row[1] as String;
@@ -254,7 +282,7 @@ class CacheManager {
       }
       _db.execute('''
         DELETE FROM cache
-        WHERE expires < ?
+        WHERE expires > 0 AND expires < ?
       ''', [DateTime.now().millisecondsSinceEpoch]);
 
       int count = 0;
@@ -268,17 +296,33 @@ class CacheManager {
       compute((path) => Directory(path).size, cachePath)
           .then((value) => _currentSize = value);
 
+      // 防御: 初始化扫描未完成时 _currentSize 可能为 null,
+      // 若 count > 2000 会进入 while 循环, 循环内 _currentSize! 将崩溃
+      if(_currentSize == null && count > 2000){
+        _currentSize = await Directory(cachePath).size;
+      }
+
       while((_currentSize != null && _currentSize! > _limitSize) ||  count > 2000){
+        // 淘汰排除永久缓存 (expires <= 0)
         var res = _db.select('''
           SELECT * FROM cache
+          WHERE expires > 0
           ORDER BY expires ASC
           limit 10
         ''');
-        // 数据库中无记录但磁盘仍超限, 直接清空缓存目录
         if(res.isEmpty){
-          await Directory(cachePath).delete(recursive: true);
-          Directory(cachePath).createSync(recursive: true);
-          _currentSize = 0;
+          // 无可淘汰的临时缓存 (expires > 0)。
+          // 仅当数据库已完全为空 (磁盘上都是孤立文件) 时才全清,
+          // 避免永久缓存 (expires <= 0) 占满空间时被无差别删除。
+          var countRes = _db.select('''
+            SELECT COUNT(*) FROM cache
+          ''');
+          var dbCount = countRes.isEmpty ? 0 : countRes.first[0] as int;
+          if(dbCount == 0){
+            await Directory(cachePath).delete(recursive: true);
+            Directory(cachePath).createSync(recursive: true);
+            _currentSize = 0;
+          }
           break;
         }
         for(var row in res){
@@ -403,6 +447,10 @@ class CachingFile{
     CacheManager()._db.execute('''
       INSERT OR REPLACE INTO cache (key, dir, name, expires) VALUES (?, ?, ?, ?)
     ''', [key, dir, name, DateTime.now().millisecondsSinceEpoch + 7 * 24 * 60 * 60 * 1000]);
+    // 将流式写入的文件大小计入全局缓存容量
+    if(CacheManager()._currentSize != null){
+      CacheManager()._currentSize = CacheManager()._currentSize! + await file.length();
+    }
     await CacheManager().checkCache();
   }
 

--- a/lib/foundation/cache_manager.dart
+++ b/lib/foundation/cache_manager.dart
@@ -193,17 +193,18 @@ class CacheManager {
       ''', [DateTime.now().millisecondsSinceEpoch]);
 
       // 第二步：获取当前条目数
-      int count = 0;
-      var res2 = _db.select('SELECT COUNT(*) FROM cache');
-      if(res2.isNotEmpty){
-        count = res2.first[0] as int;
-      }
+      // int count = 0;
+      // var res2 = _db.select('SELECT COUNT(*) FROM cache');
+      // if(res2.isNotEmpty){
+      //   count = res2.first[0] as int;
+      // }
 
       // 第三步：在主 isolate 中直接计算目录大小（移除 compute，避免 isolate OOM）
       _currentSize = await _calcDirSize(cachePath);
 
       // 第四步：循环清理直到满足限制
-      while (_currentSize! > _limitSize || count > 2000) {
+      // while (_currentSize! > _limitSize || count > 2000) {
+      while (_currentSize! > _limitSize) {
         var res3 = _db.select('''
           SELECT * FROM cache
           ORDER BY expires ASC
@@ -222,7 +223,8 @@ class CacheManager {
               _db.execute('DELETE FROM cache WHERE key = ?', [key]);
               _currentSize = _currentSize! - size;
               anyDeleted = true;
-              if(_currentSize! <= _limitSize && count - 1 <= 2000){
+              // if(_currentSize! <= _limitSize && count - 1 <= 2000){
+              if(_currentSize! <= _limitSize){
                 break;
               }
             } else {
@@ -232,7 +234,7 @@ class CacheManager {
           } catch (_) { 
             //// 权限不足或文件操作异常时跳过当前条目，继续处理下一个
           }
-          count--;
+          // count--;
         }
         if (!anyDeleted) {
           break; // 防止死循环：数据库中还有记录但文件都已不存在


### PR DESCRIPTION
# PicaComic CacheManager 优化与修复总结

**标题：磁盘缓存管理器健壮性升级 — 扫描校准、LRU 淘汰、永久缓存保护、大小统计闭环**

## 主要内容

### 1. 初始化磁盘扫描
启动时后台扫描缓存目录，删除孤立文件、校准 `_currentSize`，采用 `compute` 实现 web 兼容。

### 2. `findCache` 过期检查 + LRU 续期
过期缓存自动删除；命中缓存续期 7 天；文件丢失清理 DB 脏记录。

### 3. 永久缓存语义
`duration <= 0` 写入 `expires = 0` 永久标记；读取不删不续期；过期清理与容量淘汰均排除永久缓存。

### 4. 容量统计闭环
- 流式写入（`CachingFile.close`）计入 `_currentSize`
- 重复写入同 key（`writeCache` / `openWrite`）前置删除旧文件
- 各删除路径均同步扣减
