### PR TITLE
Fixed the issue where the language filter wasn't being applied automatically when searching again on the search results page

### DIFF
--- a/lib/pages/search_result_page.dart
+++ b/lib/pages/search_result_page.dart
@@ -115,16 +115,24 @@ class _SearchResultPageState extends State<_SearchResultPage> {
   @override
   void initState() {
     controller.text = keyword.trim();
-    if (!keyword.contains('language') &&
+    keyword = _applyLanguageFilter(keyword);
+    suggestionsController = _SuggestionsController(controller);
+    super.initState();
+  }
+
+  /// 自动添加语言筛选
+  ///
+  /// 如果该源启用了语言筛选, 且设置中选择了语言, 则在关键字后追加 `language:xxx`
+  String _applyLanguageFilter(String raw) {
+    if (!raw.contains('language') &&
         ComicSource.find(sourceKey)?.searchPageData?.enableLanguageFilter ==
             true) {
       var lang = int.tryParse(appdata.settings[69]) ?? 0;
       if (lang != 0) {
-        keyword += " language:${["chinese", "english", "japanese"][lang - 1]}";
+        raw += " language:${["chinese", "english", "japanese"][lang - 1]}";
       }
     }
-    suggestionsController = _SuggestionsController(controller);
-    super.initState();
+    return raw;
   }
 
   @override
@@ -205,7 +213,7 @@ class _SearchResultPageState extends State<_SearchResultPage> {
               onPressed: () {
                 var s = controller.text;
                 setState(() {
-                  keyword = s;
+                  keyword = _applyLanguageFilter(s);
                 });
               },
             )
@@ -244,7 +252,7 @@ class _SearchResultPageState extends State<_SearchResultPage> {
                   suggestionsController.remove();
                   if (s == keyword) return;
                   setState(() {
-                    keyword = s;
+                    keyword = _applyLanguageFilter(s);
                   });
                 },
                 controller: controller,


### PR DESCRIPTION
fix #277 

### 问题描述

在 E-Hentai（以及 nhentai、hitomi 等启用了语言筛选的源）中，开启"自动添加语言筛选"设置后：

- 从预搜索页进入搜索时，语言标签（如 `language:english`）能被正确自动追加；
- 但进入搜索结果页后，在搜索栏内修改关键字再次搜索（回车提交或点击右下角 FAB 按钮），语言标签不再被自动添加，导致语言筛选失效。

### 根因分析

自动添加语言筛选的逻辑原先只写在 `_SearchResultPageState.initState()` 中，仅在页面创建时执行一次。搜索结果页内的两个重新搜索入口（搜索栏 `onSearch` 回调、FAB 按钮 `onPressed`）只是将输入框文本原样赋给 `keyword`，并未复用该逻辑，因此再次搜索时语言标签丢失。
